### PR TITLE
Feat/gi first validator

### DIFF
--- a/programs/predeposit-guarantee.ts
+++ b/programs/predeposit-guarantee.ts
@@ -1,10 +1,43 @@
 import { program } from 'command';
+import { getCLProofVerifierContract } from 'contracts';
 
 import { createPDGProof, getFirstValidatorGIndex } from 'utils/index.js';
 
 const predepositGuarantee = program
   .command('pdg')
   .description('predeposit guarantee contract');
+
+predepositGuarantee
+  .command('create-proof-and-check')
+  .description(
+    'create predeposit proof by validator index and check by test contract',
+  )
+  .argument('<validator-index>', 'validator index')
+  .action(async (validatorIndex: bigint) => {
+    const clProofVerifierContract = getCLProofVerifierContract();
+
+    const packageProof = await createPDGProof(Number(validatorIndex));
+    const { proof, pubkey, childBlockTimestamp, withdrawalCredentials } =
+      packageProof;
+
+    await clProofVerifierContract.read.TEST_validatePubKeyWCProof([
+      { proof, pubkey, validatorIndex, childBlockTimestamp },
+      withdrawalCredentials,
+    ]);
+
+    console.info('-----------------proof verified-----------------');
+    console.info('------------------------------------------------');
+    console.info('----------------------proof----------------------');
+    console.info(proof);
+    console.info('---------------------pubkey---------------------');
+    console.table(pubkey);
+    console.info('---------------childBlockTimestamp---------------');
+    console.table(childBlockTimestamp);
+    console.info('--------------withdrawalCredentials--------------');
+    console.table(withdrawalCredentials);
+    console.info('------------------------------------------------');
+    console.info('-----------------------end-----------------------');
+  });
 
 predepositGuarantee
   .command('create-proof')

--- a/programs/predeposit-guarantee.ts
+++ b/programs/predeposit-guarantee.ts
@@ -1,7 +1,6 @@
 import { program } from 'command';
-import { getCLProofVerifierContract } from 'contracts';
 
-import { createPDGProof } from 'utils/index.js';
+import { createPDGProof, getFirstValidatorGIndex } from 'utils/index.js';
 
 const predepositGuarantee = program
   .command('pdg')
@@ -9,20 +8,12 @@ const predepositGuarantee = program
 
 predepositGuarantee
   .command('create-proof')
-  .description('create predeposit proof')
+  .description('create predeposit proof by validator index')
   .argument('<validator-index>', 'validator index')
   .action(async (validatorIndex: bigint) => {
-    const clProofVerifierContract = getCLProofVerifierContract();
-
     const packageProof = await createPDGProof(Number(validatorIndex));
     const { proof, pubkey, childBlockTimestamp, withdrawalCredentials } =
       packageProof;
-
-    // verification by test contract
-    await clProofVerifierContract.read.TEST_validatePubKeyWCProof([
-      { proof, pubkey, validatorIndex, childBlockTimestamp },
-      withdrawalCredentials,
-    ]);
 
     console.info('-----------------proof verified-----------------');
     console.info('------------------------------------------------');
@@ -36,4 +27,12 @@ predepositGuarantee
     console.table(withdrawalCredentials);
     console.info('------------------------------------------------');
     console.info('-----------------------end-----------------------');
+  });
+
+predepositGuarantee
+  .command('fv-gindex')
+  .argument('<forks...>', 'fork name')
+  .description('get first validator gindex')
+  .action(async (forks: string[]) => {
+    getFirstValidatorGIndex(forks);
   });

--- a/utils/proof/first-validator-gindex.ts
+++ b/utils/proof/first-validator-gindex.ts
@@ -1,0 +1,32 @@
+import { ssz } from '@lodestar/types';
+
+const SupportedFork = {
+  deneb: 'deneb',
+  electra: 'electra',
+};
+
+export const getFirstValidatorGIndex = (forks: string[]) => {
+  const gIndexes: Record<string, string> = {};
+  for (const fork of forks) {
+    const Fork = ssz[fork as keyof typeof SupportedFork];
+    const Validators = Fork.BeaconState.getPathInfo(['validators']).type;
+
+    const gI = pack(
+      Fork.BeaconState.getPathInfo(['validators', 0]).gindex,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      Validators.limit,
+    );
+    gIndexes[fork] = toBytes32String(gI);
+  }
+  console.table(gIndexes);
+};
+
+const pack = (gI: bigint, limit: number) => {
+  const width = limit ? BigInt(Math.log2(limit)) : 0n;
+  return (gI << 8n) | width;
+};
+
+const toBytes32String = (gI: bigint) => {
+  return `0x${gI.toString(16).padStart(64, '0')}`;
+};

--- a/utils/proof/index.ts
+++ b/utils/proof/index.ts
@@ -1,2 +1,3 @@
 export * from './merkle-utils.js';
 export * from './create-proof.js';
+export * from './first-validator-gindex.js';


### PR DESCRIPTION
### Description

New features and commands:

* [`programs/predeposit-guarantee.ts`](diffhunk://#diff-b945cb38e0b3a9c376b0eeae050d15ac41138b95e432e6b1d93ddadab10b61b9L4-R14): Added a new command `create-proof-and-check` to create a predeposit proof by validator index and check it using a test contract.
* [`programs/predeposit-guarantee.ts`](diffhunk://#diff-b945cb38e0b3a9c376b0eeae050d15ac41138b95e432e6b1d93ddadab10b61b9R41-R71): Added a new command `fv-gindex` to get the first validator gindex for specified forks.

Utility functions:

* [`utils/proof/first-validator-gindex.ts`](diffhunk://#diff-b1c1aaaffa669b70cc85fdc428d896d27b70549913b2792cffef20d96fc30e80R1-R32): Introduced a new utility function `getFirstValidatorGIndex` to calculate the first validator gindex for specified forks.
* [`utils/proof/index.ts`](diffhunk://#diff-99f64b824d93f066e2b467ba6cc2cc092ddb4b9f9d08ab02987086e6a7d5efabR3): Exported the new utility function `getFirstValidatorGIndex` from the `proof` module.

Enhancements:

* [`programs/predeposit-guarantee.ts`](diffhunk://#diff-b945cb38e0b3a9c376b0eeae050d15ac41138b95e432e6b1d93ddadab10b61b9R41-R71): Enhanced the `create-proof` command with additional logging to display proof details.

### Demo

<img width="601" alt="image" src="https://github.com/user-attachments/assets/d54c66f8-6ef6-4e3d-a341-720b72fec90f" />

### Code review notes

<!-- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!-- List all possible edge cases and how to test them. -->

### Checklist:

- [x]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

