### PR TITLE
feat: add PredepositGuarantee contract and CLI commands for predeposi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,58 @@ lsv-cli delegation -h
 | role-revoke \<address> \<roleAssignmentJSON>               | Resumes beacon chain deposits on the staking vault.                                                                     |
 | set-confirm-expiry \<address> \<newConfirmExpiry>          | set the confirmation expiry                                                                                             |
 
+### PredepositGuarantee
+
+#### Command
+
+```bash
+lsv-cli pdg [arguments] [-options]
+```
+
+#### Delegation commands list
+
+```bash
+lsv-cli pdg -h
+```
+
+#### API
+
+| Command                                      | Description                                                                     |
+| -------------------------------------------- | ------------------------------------------------------------------------------- |
+| BEACON_ROOTS                                 | Calls the read-only function "BEACON_ROOTS" on the contract.                    |
+| DEFAULT_ADMIN_ROLE                           | Calls the read-only function "DEFAULT_ADMIN_ROLE" on the contract.              |
+| GI_FIRST_VALIDATOR                           | Calls the read-only function "GI_FIRST_VALIDATOR" on the contract.              |
+| GI_FIRST_VALIDATOR_AFTER_CHANGE              | Calls the read-only function "GI_FIRST_VALIDATOR_AFTER_CHANGE" on the contract. |
+| GI_PUBKEY_WC_PARENT                          | Calls the read-only function "GI_PUBKEY_WC_PARENT" on the contract.             |
+| GI_STATE_ROOT                                | Calls the read-only function "GI_STATE_ROOT" on the contract.                   |
+| MAX_SUPPORTED_WC_VERSION                     | Calls the read-only function "MAX_SUPPORTED_WC_VERSION" on the contract.        |
+| MIN_SUPPORTED_WC_VERSION                     | Calls the read-only function "MIN_SUPPORTED_WC_VERSION" on the contract.        |
+| PAUSE_INFINITELY                             | Calls the read-only function "PAUSE_INFINITELY" on the contract.                |
+| PAUSE_ROLE                                   | Calls the read-only function "PAUSE_ROLE" on the contract.                      |
+| PREDEPOSIT_AMOUNT                            | Calls the read-only function "PREDEPOSIT_AMOUNT" on the contract.               |
+| RESUME_ROLE                                  | Calls the read-only function "RESUME_ROLE" on the contract.                     |
+| SLOT_CHANGE_GI_FIRST_VALIDATOR               | Calls the read-only function "SLOT_CHANGE_GI_FIRST_VALIDATOR" on the contract.  |
+| STATE_ROOT_DEPTH                             | Calls the read-only function "STATE_ROOT_DEPTH" on the contract.                |
+| STATE_ROOT_POSITION                          | Calls the read-only function "STATE_ROOT_POSITION" on the contract.             |
+| WC_PUBKEY_PARENT_DEPTH                       | Calls the read-only function "WC_PUBKEY_PARENT_DEPTH" on the contract.          |
+| WC_PUBKEY_PARENT_POSITION                    | Calls the read-only function "WC_PUBKEY_PARENT_POSITION" on the contract.       |
+| claimableRefund \<\_guarantor>               | Calls the read-only function "claimableRefund" on the contract.                 |
+| getResumeSinceTimestamp                      | Calls the read-only function "getResumeSinceTimestamp" on the contract.         |
+| getRoleAdmin \<role>                         | Calls the read-only function "getRoleAdmin" on the contract.                    |
+| getRoleMember \<role> \<index>               | Calls the read-only function "getRoleMember" on the contract.                   |
+| getRoleMemberCount \<role>                   | Calls the read-only function "getRoleMemberCount" on the contract.              |
+| getRoleMembers \<role>                       | Calls the read-only function "getRoleMembers" on the contract.                  |
+| hasRole \<role> \<account>                   | Calls the read-only function "hasRole" on the contract.                         |
+| isPaused                                     | Calls the read-only function "isPaused" on the contract.                        |
+| nodeOperatorBalance \<\_nodeOperator>        | Calls the read-only function "nodeOperatorBalance" on the contract.             |
+| nodeOperatorGuarantor \<\_nodeOperator>      | Calls the read-only function "nodeOperatorGuarantor" on the contract.           |
+| supportsInterface \<interfaceId>             | Calls the read-only function "supportsInterface" on the contract.               |
+| unlockedBalance \<\_nodeOperator>            | Calls the read-only function "unlockedBalance" on the contract.                 |
+| validatorStatus \<\_validatorPubkey>         | Calls the read-only function "validatorStatus" on the contract.                 |
+| predeposit \<vault> \<deposits>              | predeposit                                                                      |
+| create-proof-and-prove \<index>              | create proof and prove                                                          |
+| deposit-to-beacon-chain \<vault> \<deposits> | deposit to beacon chain                                                         |
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/abi/LidoLocator.ts
+++ b/abi/LidoLocator.ts
@@ -1,384 +1,425 @@
-export const lidoLocator = [
+export const LidoLocatorAbi = [
   {
-    "inputs": [
+    inputs: [
       {
-        "components": [
+        components: [
           {
-            "internalType": "address",
-            "name": "accountingOracle",
-            "type": "address"
+            internalType: 'address',
+            name: 'accountingOracle',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "depositSecurityModule",
-            "type": "address"
+            internalType: 'address',
+            name: 'depositSecurityModule',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "elRewardsVault",
-            "type": "address"
+            internalType: 'address',
+            name: 'elRewardsVault',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "legacyOracle",
-            "type": "address"
+            internalType: 'address',
+            name: 'legacyOracle',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "lido",
-            "type": "address"
+            internalType: 'address',
+            name: 'lido',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "oracleReportSanityChecker",
-            "type": "address"
+            internalType: 'address',
+            name: 'oracleReportSanityChecker',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "postTokenRebaseReceiver",
-            "type": "address"
+            internalType: 'address',
+            name: 'postTokenRebaseReceiver',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "burner",
-            "type": "address"
+            internalType: 'address',
+            name: 'burner',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "stakingRouter",
-            "type": "address"
+            internalType: 'address',
+            name: 'stakingRouter',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "treasury",
-            "type": "address"
+            internalType: 'address',
+            name: 'treasury',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "validatorsExitBusOracle",
-            "type": "address"
+            internalType: 'address',
+            name: 'validatorsExitBusOracle',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "withdrawalQueue",
-            "type": "address"
+            internalType: 'address',
+            name: 'withdrawalQueue',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "withdrawalVault",
-            "type": "address"
+            internalType: 'address',
+            name: 'withdrawalVault',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "oracleDaemonConfig",
-            "type": "address"
+            internalType: 'address',
+            name: 'oracleDaemonConfig',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "accounting",
-            "type": "address"
+            internalType: 'address',
+            name: 'accounting',
+            type: 'address',
           },
           {
-            "internalType": "address",
-            "name": "wstETH",
-            "type": "address"
-          }
+            internalType: 'address',
+            name: 'predepositGuarantee',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'wstETH',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'vaultHub',
+            type: 'address',
+          },
         ],
-        "internalType": "struct LidoLocator.Config",
-        "name": "_config",
-        "type": "tuple"
-      }
+        internalType: 'struct LidoLocator.Config',
+        name: '_config',
+        type: 'tuple',
+      },
     ],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
+    stateMutability: 'nonpayable',
+    type: 'constructor',
   },
   {
-    "inputs": [],
-    "name": "ZeroAddress",
-    "type": "error"
+    inputs: [],
+    name: 'ZeroAddress',
+    type: 'error',
   },
   {
-    "inputs": [],
-    "name": "accounting",
-    "outputs": [
+    inputs: [],
+    name: 'accounting',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "accountingOracle",
-    "outputs": [
+    inputs: [],
+    name: 'accountingOracle',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "burner",
-    "outputs": [
+    inputs: [],
+    name: 'burner',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "coreComponents",
-    "outputs": [
+    inputs: [],
+    name: 'coreComponents',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address',
       },
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address',
       },
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address',
       },
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address',
       },
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address',
       },
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "depositSecurityModule",
-    "outputs": [
+    inputs: [],
+    name: 'depositSecurityModule',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "elRewardsVault",
-    "outputs": [
+    inputs: [],
+    name: 'elRewardsVault',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "legacyOracle",
-    "outputs": [
+    inputs: [],
+    name: 'legacyOracle',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "lido",
-    "outputs": [
+    inputs: [],
+    name: 'lido',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "oracleDaemonConfig",
-    "outputs": [
+    inputs: [],
+    name: 'oracleDaemonConfig',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "oracleReportComponents",
-    "outputs": [
+    inputs: [],
+    name: 'oracleReportComponents',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address',
       },
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address',
       },
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address',
       },
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address',
       },
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        internalType: 'address',
+        name: '',
+        type: 'address',
       },
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "oracleReportSanityChecker",
-    "outputs": [
+    inputs: [],
+    name: 'oracleReportSanityChecker',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "postTokenRebaseReceiver",
-    "outputs": [
+    inputs: [],
+    name: 'postTokenRebaseReceiver',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "stakingRouter",
-    "outputs": [
+    inputs: [],
+    name: 'predepositGuarantee',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "treasury",
-    "outputs": [
+    inputs: [],
+    name: 'stakingRouter',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "validatorsExitBusOracle",
-    "outputs": [
+    inputs: [],
+    name: 'treasury',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "withdrawalQueue",
-    "outputs": [
+    inputs: [],
+    name: 'validatorsExitBusOracle',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "withdrawalVault",
-    "outputs": [
+    inputs: [],
+    name: 'vaultHub',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    stateMutability: 'view',
+    type: 'function',
   },
   {
-    "inputs": [],
-    "name": "wstETH",
-    "outputs": [
+    inputs: [],
+    name: 'withdrawalQueue',
+    outputs: [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
-  }
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'withdrawalVault',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'wstETH',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
 ] as const;

--- a/abi/PredepositGuarantee.ts
+++ b/abi/PredepositGuarantee.ts
@@ -1,0 +1,1732 @@
+export const PredepositGuaranteeAbi = [
+  {
+    inputs: [
+      {
+        internalType: 'GIndex',
+        name: '_gIFirstValidator',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'GIndex',
+        name: '_gIFirstValidatorAfterChange',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'uint64',
+        name: '_changeSlot',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    inputs: [],
+    name: 'AccessControlBadConfirmation',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        internalType: 'bytes32',
+        name: 'neededRole',
+        type: 'bytes32',
+      },
+    ],
+    name: 'AccessControlUnauthorizedAccount',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'CompensateFailed',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'CompensateToVaultNotAllowed',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes',
+        name: 'validatorPubkey',
+        type: 'bytes',
+      },
+      {
+        internalType: 'enum PredepositGuarantee.validatorStage',
+        name: 'stage',
+        type: 'uint8',
+      },
+    ],
+    name: 'DepositToUnprovenValidator',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes',
+        name: 'validatorPubkey',
+        type: 'bytes',
+      },
+      {
+        internalType: 'address',
+        name: 'stakingVault',
+        type: 'address',
+      },
+    ],
+    name: 'DepositToWrongVault',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'EmptyDeposits',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'IndexOutOfRange',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidInitialization',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidPubkeyLength',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'InvalidTimestamp',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'locked',
+        type: 'uint256',
+      },
+    ],
+    name: 'LockedIsNotZero',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'unlocked',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'NotEnoughUnlocked',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'NotGuarantor',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'NotInitializing',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'NotNodeOperator',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'NotStakingVaultOwner',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'NothingToRefund',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'PauseUntilMustBeInFuture',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'PausedExpected',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes',
+        name: 'validatorPubkey',
+        type: 'bytes',
+      },
+      {
+        internalType: 'uint256',
+        name: 'depositAmount',
+        type: 'uint256',
+      },
+    ],
+    name: 'PredepositAmountInvalid',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'RefundFailed',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ResumedExpected',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'RootNotFound',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'SameGuarantor',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'enum PredepositGuarantee.validatorStage',
+        name: 'stage',
+        type: 'uint8',
+      },
+    ],
+    name: 'ValidatorNotDisproven',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes',
+        name: 'validatorPubkey',
+        type: 'bytes',
+      },
+      {
+        internalType: 'enum PredepositGuarantee.validatorStage',
+        name: 'stage',
+        type: 'uint8',
+      },
+    ],
+    name: 'ValidatorNotNew',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes',
+        name: 'validatorPubkey',
+        type: 'bytes',
+      },
+      {
+        internalType: 'enum PredepositGuarantee.validatorStage',
+        name: 'stage',
+        type: 'uint8',
+      },
+    ],
+    name: 'ValidatorNotPreDeposited',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'ValueNotMultipleOfPredepositAmount',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint8',
+        name: 'version',
+        type: 'uint8',
+      },
+    ],
+    name: 'WithdrawalCredentialsInvalidVersion',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'WithdrawalCredentialsMatch',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'withdrawalCredentials',
+        type: 'bytes32',
+      },
+    ],
+    name: 'WithdrawalCredentialsMisformed',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'stakingVault',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: 'withdrawalCredentialsAddress',
+        type: 'address',
+      },
+    ],
+    name: 'WithdrawalCredentialsMismatch',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'WithdrawalFailed',
+    type: 'error',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'string',
+        name: 'argument',
+        type: 'string',
+      },
+    ],
+    name: 'ZeroArgument',
+    type: 'error',
+  },
+  {
+    inputs: [],
+    name: 'ZeroPauseDuration',
+    type: 'error',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'nodeOperator',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint128',
+        name: 'total',
+        type: 'uint128',
+      },
+      {
+        indexed: false,
+        internalType: 'uint128',
+        name: 'locked',
+        type: 'uint128',
+      },
+    ],
+    name: 'BalanceCompensated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'nodeOperator',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint128',
+        name: 'total',
+        type: 'uint128',
+      },
+      {
+        indexed: false,
+        internalType: 'uint128',
+        name: 'locked',
+        type: 'uint128',
+      },
+    ],
+    name: 'BalanceLocked',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'nodeOperator',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address',
+      },
+    ],
+    name: 'BalanceRefunded',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'nodeOperator',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'BalanceToppedUp',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'nodeOperator',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint128',
+        name: 'total',
+        type: 'uint128',
+      },
+      {
+        indexed: false,
+        internalType: 'uint128',
+        name: 'locked',
+        type: 'uint128',
+      },
+    ],
+    name: 'BalanceUnlocked',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'nodeOperator',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'recipient',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'BalanceWithdrawn',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'guarantor',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'nodeOperator',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'GuarantorRefundAdded',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'guarantor',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'recipient',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256',
+      },
+    ],
+    name: 'GuarantorRefundClaimed',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'nodeOperator',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'newGuarantor',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'prevGuarantor',
+        type: 'address',
+      },
+    ],
+    name: 'GuarantorSet',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint64',
+        name: 'version',
+        type: 'uint64',
+      },
+    ],
+    name: 'Initialized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'duration',
+        type: 'uint256',
+      },
+    ],
+    name: 'Paused',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [],
+    name: 'Resumed',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'previousAdminRole',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'newAdminRole',
+        type: 'bytes32',
+      },
+    ],
+    name: 'RoleAdminChanged',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+    ],
+    name: 'RoleGranted',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'sender',
+        type: 'address',
+      },
+    ],
+    name: 'RoleRevoked',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes',
+        name: 'validatorPubkey',
+        type: 'bytes',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'nodeOperator',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'stakingVault',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'address',
+        name: 'recipient',
+        type: 'address',
+      },
+    ],
+    name: 'ValidatorCompensated',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes',
+        name: 'validatorPubkey',
+        type: 'bytes',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'nodeOperator',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'stakingVault',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'invalidWithdrawalCredentials',
+        type: 'bytes32',
+      },
+    ],
+    name: 'ValidatorDisproven',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes',
+        name: 'validatorPubkey',
+        type: 'bytes',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'nodeOperator',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'stakingVault',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'withdrawalCredentials',
+        type: 'bytes32',
+      },
+    ],
+    name: 'ValidatorPreDeposited',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes',
+        name: 'validatorPubkey',
+        type: 'bytes',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'nodeOperator',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'stakingVault',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'bytes32',
+        name: 'withdrawalCredentials',
+        type: 'bytes32',
+      },
+    ],
+    name: 'ValidatorProven',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'BEACON_ROOTS',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'DEFAULT_ADMIN_ROLE',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'GI_FIRST_VALIDATOR',
+    outputs: [
+      {
+        internalType: 'GIndex',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'GI_FIRST_VALIDATOR_AFTER_CHANGE',
+    outputs: [
+      {
+        internalType: 'GIndex',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'GI_PUBKEY_WC_PARENT',
+    outputs: [
+      {
+        internalType: 'GIndex',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'GI_STATE_ROOT',
+    outputs: [
+      {
+        internalType: 'GIndex',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'MAX_SUPPORTED_WC_VERSION',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'MIN_SUPPORTED_WC_VERSION',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'PAUSE_INFINITELY',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'PAUSE_ROLE',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'PREDEPOSIT_AMOUNT',
+    outputs: [
+      {
+        internalType: 'uint128',
+        name: '',
+        type: 'uint128',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'RESUME_ROLE',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'SLOT_CHANGE_GI_FIRST_VALIDATOR',
+    outputs: [
+      {
+        internalType: 'uint64',
+        name: '',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'STATE_ROOT_DEPTH',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'STATE_ROOT_POSITION',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'WC_PUBKEY_PARENT_DEPTH',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'WC_PUBKEY_PARENT_POSITION',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_recipient',
+        type: 'address',
+      },
+    ],
+    name: 'claimGuarantorRefund',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'claimedEther',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_guarantor',
+        type: 'address',
+      },
+    ],
+    name: 'claimableRefund',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes',
+        name: '_validatorPubkey',
+        type: 'bytes',
+      },
+      {
+        internalType: 'address',
+        name: '_recipient',
+        type: 'address',
+      },
+    ],
+    name: 'compensateDisprovenPredeposit',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IStakingVault',
+        name: '_stakingVault',
+        type: 'address',
+      },
+      {
+        components: [
+          {
+            internalType: 'bytes',
+            name: 'pubkey',
+            type: 'bytes',
+          },
+          {
+            internalType: 'bytes',
+            name: 'signature',
+            type: 'bytes',
+          },
+          {
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'depositDataRoot',
+            type: 'bytes32',
+          },
+        ],
+        internalType: 'struct IStakingVault.Deposit[]',
+        name: '_deposits',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'depositToBeaconChain',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'getResumeSinceTimestamp',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getRoleAdmin',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'uint256',
+        name: 'index',
+        type: 'uint256',
+      },
+    ],
+    name: 'getRoleMember',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getRoleMemberCount',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+    ],
+    name: 'getRoleMembers',
+    outputs: [
+      {
+        internalType: 'address[]',
+        name: '',
+        type: 'address[]',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'grantRole',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'hasRole',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_defaultAdmin',
+        type: 'address',
+      },
+    ],
+    name: 'initialize',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'isPaused',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_nodeOperator',
+        type: 'address',
+      },
+    ],
+    name: 'nodeOperatorBalance',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'uint128',
+            name: 'total',
+            type: 'uint128',
+          },
+          {
+            internalType: 'uint128',
+            name: 'locked',
+            type: 'uint128',
+          },
+        ],
+        internalType: 'struct PredepositGuarantee.NodeOperatorBalance',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_nodeOperator',
+        type: 'address',
+      },
+    ],
+    name: 'nodeOperatorGuarantor',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_duration',
+        type: 'uint256',
+      },
+    ],
+    name: 'pauseFor',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_pauseUntilInclusive',
+        type: 'uint256',
+      },
+    ],
+    name: 'pauseUntil',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'contract IStakingVault',
+        name: '_stakingVault',
+        type: 'address',
+      },
+      {
+        components: [
+          {
+            internalType: 'bytes',
+            name: 'pubkey',
+            type: 'bytes',
+          },
+          {
+            internalType: 'bytes',
+            name: 'signature',
+            type: 'bytes',
+          },
+          {
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'depositDataRoot',
+            type: 'bytes32',
+          },
+        ],
+        internalType: 'struct IStakingVault.Deposit[]',
+        name: '_deposits',
+        type: 'tuple[]',
+      },
+    ],
+    name: 'predeposit',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]',
+          },
+          {
+            internalType: 'bytes',
+            name: 'pubkey',
+            type: 'bytes',
+          },
+          {
+            internalType: 'uint256',
+            name: 'validatorIndex',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint64',
+            name: 'childBlockTimestamp',
+            type: 'uint64',
+          },
+        ],
+        internalType: 'struct CLProofVerifier.ValidatorWitness[]',
+        name: '_witnesses',
+        type: 'tuple[]',
+      },
+      {
+        components: [
+          {
+            internalType: 'bytes',
+            name: 'pubkey',
+            type: 'bytes',
+          },
+          {
+            internalType: 'bytes',
+            name: 'signature',
+            type: 'bytes',
+          },
+          {
+            internalType: 'uint256',
+            name: 'amount',
+            type: 'uint256',
+          },
+          {
+            internalType: 'bytes32',
+            name: 'depositDataRoot',
+            type: 'bytes32',
+          },
+        ],
+        internalType: 'struct IStakingVault.Deposit[]',
+        name: '_deposits',
+        type: 'tuple[]',
+      },
+      {
+        internalType: 'contract IStakingVault',
+        name: '_stakingVault',
+        type: 'address',
+      },
+    ],
+    name: 'proveAndDeposit',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]',
+          },
+          {
+            internalType: 'bytes',
+            name: 'pubkey',
+            type: 'bytes',
+          },
+          {
+            internalType: 'uint256',
+            name: 'validatorIndex',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint64',
+            name: 'childBlockTimestamp',
+            type: 'uint64',
+          },
+        ],
+        internalType: 'struct CLProofVerifier.ValidatorWitness',
+        name: '_witness',
+        type: 'tuple',
+      },
+      {
+        internalType: 'bytes32',
+        name: '_invalidWithdrawalCredentials',
+        type: 'bytes32',
+      },
+    ],
+    name: 'proveInvalidValidatorWC',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]',
+          },
+          {
+            internalType: 'bytes',
+            name: 'pubkey',
+            type: 'bytes',
+          },
+          {
+            internalType: 'uint256',
+            name: 'validatorIndex',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint64',
+            name: 'childBlockTimestamp',
+            type: 'uint64',
+          },
+        ],
+        internalType: 'struct CLProofVerifier.ValidatorWitness',
+        name: '_witness',
+        type: 'tuple',
+      },
+      {
+        internalType: 'contract IStakingVault',
+        name: '_stakingVault',
+        type: 'address',
+      },
+    ],
+    name: 'proveUnknownValidator',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: 'bytes32[]',
+            name: 'proof',
+            type: 'bytes32[]',
+          },
+          {
+            internalType: 'bytes',
+            name: 'pubkey',
+            type: 'bytes',
+          },
+          {
+            internalType: 'uint256',
+            name: 'validatorIndex',
+            type: 'uint256',
+          },
+          {
+            internalType: 'uint64',
+            name: 'childBlockTimestamp',
+            type: 'uint64',
+          },
+        ],
+        internalType: 'struct CLProofVerifier.ValidatorWitness',
+        name: '_witness',
+        type: 'tuple',
+      },
+    ],
+    name: 'proveValidatorWC',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: 'callerConfirmation',
+        type: 'address',
+      },
+    ],
+    name: 'renounceRole',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'resume',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes32',
+        name: 'role',
+        type: 'bytes32',
+      },
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address',
+      },
+    ],
+    name: 'revokeRole',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_newGuarantor',
+        type: 'address',
+      },
+    ],
+    name: 'setNodeOperatorGuarantor',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes4',
+        name: 'interfaceId',
+        type: 'bytes4',
+      },
+    ],
+    name: 'supportsInterface',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_nodeOperator',
+        type: 'address',
+      },
+    ],
+    name: 'topUpNodeOperatorBalance',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_nodeOperator',
+        type: 'address',
+      },
+    ],
+    name: 'unlockedBalance',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'unlocked',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'bytes',
+        name: '_validatorPubkey',
+        type: 'bytes',
+      },
+    ],
+    name: 'validatorStatus',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'enum PredepositGuarantee.validatorStage',
+            name: 'stage',
+            type: 'uint8',
+          },
+          {
+            internalType: 'contract IStakingVault',
+            name: 'stakingVault',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'nodeOperator',
+            type: 'address',
+          },
+        ],
+        internalType: 'struct PredepositGuarantee.ValidatorStatus',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_nodeOperator',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'address',
+        name: '_recipient',
+        type: 'address',
+      },
+    ],
+    name: 'withdrawNodeOperatorBalance',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;

--- a/abi/index.ts
+++ b/abi/index.ts
@@ -9,3 +9,4 @@ export * from './TokenManager.js';
 export * from './Voting.js';
 export * from './VaultHubViewer.js';
 export * from './CLProofVerifier.js';
+export * from './PredepositGuarantee.js';

--- a/contracts/index.ts
+++ b/contracts/index.ts
@@ -9,3 +9,4 @@ export * from './token-manager.js';
 export * from './voting.js';
 export * from './vault-hub-viewer.js';
 export * from './clProofVerifier.js';
+export * from './pdg.js';

--- a/contracts/locator.ts
+++ b/contracts/locator.ts
@@ -1,5 +1,5 @@
 import { getContract, createPublicClient, http } from 'viem';
-import { lidoLocator } from 'abi/index.js';
+import { LidoLocatorAbi } from 'abi';
 import { getChain, getLocatorAddress, getRpcUrl } from 'configs';
 
 export const getLocatorContract = () => {
@@ -8,7 +8,7 @@ export const getLocatorContract = () => {
 
   return getContract({
     address,
-    abi: lidoLocator,
+    abi: LidoLocatorAbi,
     client: createPublicClient({
       chain: getChain(),
       transport: http(rpcUrl),

--- a/contracts/pdg.ts
+++ b/contracts/pdg.ts
@@ -1,0 +1,18 @@
+import { getContract, createPublicClient, http } from 'viem';
+import { PredepositGuaranteeAbi } from 'abi/index.js';
+import { getChain, getRpcUrl } from 'configs';
+import { getLocatorContract } from 'contracts';
+
+export const getPredepositGuaranteeContract = async () => {
+  const locator = getLocatorContract();
+  const address = await locator.read.predepositGuarantee();
+
+  return getContract({
+    address,
+    abi: PredepositGuaranteeAbi,
+    client: createPublicClient({
+      chain: getChain(),
+      transport: http(getRpcUrl()),
+    }),
+  });
+};

--- a/programs/index.ts
+++ b/programs/index.ts
@@ -7,3 +7,4 @@ export * from './vault/index.js';
 export * from './dashboard/index.js';
 export * from './vault-factory/index.js';
 export * from './delegation/index.js';
+export * from './pdg/index.js';

--- a/programs/pdg/config.ts
+++ b/programs/pdg/config.ts
@@ -1,0 +1,3 @@
+import { ReadProgramCommandConfig } from 'utils';
+
+export const readCommandConfig: ReadProgramCommandConfig = {};

--- a/programs/pdg/index.ts
+++ b/programs/pdg/index.ts
@@ -1,0 +1,3 @@
+export * from './main.js';
+export * from './read.js';
+export * from './write.js';

--- a/programs/pdg/main.ts
+++ b/programs/pdg/main.ts
@@ -1,0 +1,13 @@
+import { program } from 'command';
+import { Option } from 'commander';
+import { getCommandsJson } from 'utils';
+
+export const pdg = program
+  .command('pdg')
+  .description('predeposit guarantee contract');
+
+pdg.addOption(new Option('-cmd2json'));
+pdg.on('option:-cmd2json', function () {
+  console.info(getCommandsJson(pdg));
+  process.exit();
+});

--- a/programs/pdg/read.ts
+++ b/programs/pdg/read.ts
@@ -1,0 +1,13 @@
+import { generateReadCommands } from 'utils';
+import { PredepositGuaranteeAbi } from 'abi';
+
+import { pdg } from './main.js';
+import { readCommandConfig } from './config.js';
+import { getPredepositGuaranteeContract } from 'contracts';
+
+generateReadCommands(
+  PredepositGuaranteeAbi,
+  getPredepositGuaranteeContract,
+  pdg,
+  readCommandConfig,
+);

--- a/programs/pdg/write.ts
+++ b/programs/pdg/write.ts
@@ -1,0 +1,84 @@
+import { Address, Hex } from 'viem';
+
+import { getPredepositGuaranteeContract } from 'contracts';
+import {
+  callWriteMethodWithReceipt,
+  confirmCreateProof,
+  createPDGProof,
+  showSpinner,
+  printError,
+} from 'utils';
+
+import { pdg } from './main.js';
+
+interface Deposit {
+  pubkey: Hex;
+  signature: Hex;
+  amount: bigint;
+  depositDataRoot: Hex;
+}
+
+pdg
+  .command('predeposit')
+  .description('predeposit')
+  .argument('<vault>', 'vault address')
+  .argument('<deposits>', 'deposits')
+  .action(async (vault: Address, deposits: Deposit[]) => {
+    const pdgContract = await getPredepositGuaranteeContract();
+
+    await callWriteMethodWithReceipt(pdgContract, 'predeposit', [
+      vault,
+      deposits,
+    ]);
+  });
+
+pdg
+  .command('create-proof-and-prove')
+  .description('create proof and prove')
+  .argument('<index>', 'validator index')
+  .action(async (index: bigint) => {
+    const pdgContract = await getPredepositGuaranteeContract();
+
+    const validatorIndex = await confirmCreateProof(index);
+    if (!validatorIndex) return;
+
+    const hideSpinner = showSpinner();
+    try {
+      const packageProof = await createPDGProof(Number(validatorIndex));
+      hideSpinner();
+      const { proof, pubkey, childBlockTimestamp, withdrawalCredentials } =
+        packageProof;
+
+      console.info('----------------------proof----------------------');
+      console.info(proof);
+      console.info('---------------------pubkey---------------------');
+      console.table(pubkey);
+      console.info('---------------childBlockTimestamp---------------');
+      console.table(childBlockTimestamp);
+      console.info('--------------withdrawalCredentials--------------');
+      console.table(withdrawalCredentials);
+      console.info('------------------------------------------------');
+      console.info('-----------------------end-----------------------');
+
+      await callWriteMethodWithReceipt(pdgContract, 'proveValidatorWC', [
+        { proof, pubkey, validatorIndex, childBlockTimestamp },
+      ]);
+    } catch (err) {
+      hideSpinner();
+      printError(err, 'Error when creating proof');
+    }
+  });
+
+pdg
+  .command('deposit-to-beacon-chain')
+  .description('deposit to beacon chain')
+  .argument('<vault>', 'vault address')
+  .argument('<deposits>', 'deposits')
+  .action(async (vault: Address, deposits: Deposit[]) => {
+    const pdgContract = await getPredepositGuaranteeContract();
+
+    await callWriteMethodWithReceipt(pdgContract, 'depositToBeaconChain', [
+      vault,
+      deposits,
+    ]);
+  });

--- a/programs/pdg/write.ts
+++ b/programs/pdg/write.ts
@@ -42,7 +42,10 @@ pdg
     const validatorIndex = await confirmCreateProof(index);
     if (!validatorIndex) return;
 
-    const hideSpinner = showSpinner();
+    const hideSpinner = showSpinner({
+      type: 'bouncingBar',
+      message: 'Creating proof...',
+    });
     try {
       const packageProof = await createPDGProof(Number(validatorIndex));
       hideSpinner();

--- a/programs/predeposit-guarantee.ts
+++ b/programs/predeposit-guarantee.ts
@@ -9,11 +9,11 @@ import {
   printError,
 } from 'utils/index.js';
 
-const predepositGuarantee = program
-  .command('pdg')
-  .description('predeposit guarantee contract');
+const predepositGuaranteeHelpers = program
+  .command('pdg-helpers')
+  .description('predeposit guarantee helpers');
 
-predepositGuarantee
+predepositGuaranteeHelpers
   .command('create-proof-and-check')
   .option('-i, --index <index>', 'validator index')
   .description(
@@ -55,7 +55,7 @@ predepositGuarantee
     }
   });
 
-predepositGuarantee
+predepositGuaranteeHelpers
   .command('create-proof')
   .description('create predeposit proof by validator index')
   .option('-i, --index <index>', 'validator index')
@@ -81,7 +81,7 @@ predepositGuarantee
     console.info('-----------------------end-----------------------');
   });
 
-predepositGuarantee
+predepositGuaranteeHelpers
   .command('fv-gindex')
   .argument('<forks...>', 'fork name')
   .description('get first validator gindex')


### PR DESCRIPTION
### Description

### New Feature: PredepositGuarantee

* **Documentation Update:**
  * Added a new section `PredepositGuarantee` in `README.md` with command descriptions and API details.

* **Exports and Imports:**
  * Added exports for `PredepositGuarantee` in `abi/index.ts`, `contracts/index.ts`, and `programs/index.ts`. [[1]](diffhunk://#diff-d3d6ba412590524db4d9e70f11f679b24fe88cf0559cadc472b6b1ae152429bdR12) [[2]](diffhunk://#diff-627dcd00d3de19f0382b5cffaa5a1d6620856cd69ebaaac16fd75188de421dc2R12) [[3]](diffhunk://#diff-51ea5e664738c214aa52121ef2946afe19938c414be57609e9745d3bb49f6bc0R10)
  * Updated import for `LidoLocatorAbi` in `contracts/locator.ts`. [[1]](diffhunk://#diff-75d1684883407a9a4e0ddd44791fce31ef1730c1de3741c4a5bf8a7a8a776175L2-R2) [[2]](diffhunk://#diff-75d1684883407a9a4e0ddd44791fce31ef1730c1de3741c4a5bf8a7a8a776175L11-R11)

* **Contract Handling:**
  * Added `getPredepositGuaranteeContract` function in `contracts/pdg.ts` to retrieve the contract instance.

* **Program Commands:**
  * Added new commands in `programs/pdg` for handling predeposit guarantees, including `main.ts`, `read.ts`, and `write.ts`. [[1]](diffhunk://#diff-7ccfadf0531cb19e1461a4d934919265057b95e6dfaa0823dda36a1c051124bbR1-R13) [[2]](diffhunk://#diff-329e551d262ccbd8f53a551906a4469ffce1583b108e812b26341de54a5ed10fR1-R13) [[3]](diffhunk://#diff-8e0ed6acdbd934ce75dde977fc2330b51e3ee0bfbd1497806c15136c490ea40fR1-R84)
  * Renamed and updated commands in `programs/predeposit-guarantee.ts` to `pdg-helpers`. [[1]](diffhunk://#diff-b945cb38e0b3a9c376b0eeae050d15ac41138b95e432e6b1d93ddadab10b61b9L12-R16) [[2]](diffhunk://#diff-b945cb38e0b3a9c376b0eeae050d15ac41138b95e432e6b1d93ddadab10b61b9L58-R58) [[3]](diffhunk://#diff-b945cb38e0b3a9c376b0eeae050d15ac41138b95e432e6b1d93ddadab10b61b9L84-R84)

* **Utility Functions:**
  * Enhanced `generateReadCommands` in `utils/read-programs-by-abi.ts` to support asynchronous contract creation and handle read-only functions more effectively. [[1]](diffhunk://#diff-2bb219e432e7a137d1f2de0892cc9a2c7fd3cb13d37c97e9e1c6c07d8e3ebaf9R19-R45) [[2]](diffhunk://#diff-2bb219e432e7a137d1f2de0892cc9a2c7fd3cb13d37c97e9e1c6c07d8e3ebaf9R54-R61) [[3]](diffhunk://#diff-2bb219e432e7a137d1f2de0892cc9a2c7fd3cb13d37c97e9e1c6c07d8e3ebaf9L57-R84) [[4]](diffhunk://#diff-2bb219e432e7a137d1f2de0892cc9a2c7fd3cb13d37c97e9e1c6c07d8e3ebaf9L82-R130) [[5]](diffhunk://#diff-2bb219e432e7a137d1f2de0892cc9a2c7fd3cb13d37c97e9e1c6c07d8e3ebaf9L102-R142)

### Demo

<!-- If thee are visual changes add screenshots or record a [loom](https://www.loom.com/). -->

### Code review notes

<!-- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!-- List all possible edge cases and how to test them. -->

### Checklist:

- [ ]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

