### PR TITLE
feat: add totalValueRemainder field to VaultViewer ABI and update con…

### DIFF
--- a/abi/VaultViewer.ts
+++ b/abi/VaultViewer.ts
@@ -378,6 +378,11 @@ export const VaultViewerAbi = [
                 name: 'endTimestamp',
                 type: 'uint256',
               },
+              {
+                internalType: 'uint256',
+                name: 'totalValueRemainder',
+                type: 'uint256',
+              },
             ],
             internalType: 'struct LazyOracle.QuarantineInfo',
             name: 'quarantineInfo',
@@ -592,6 +597,11 @@ export const VaultViewerAbi = [
               {
                 internalType: 'uint256',
                 name: 'endTimestamp',
+                type: 'uint256',
+              },
+              {
+                internalType: 'uint256',
+                name: 'totalValueRemainder',
                 type: 'uint256',
               },
             ],

--- a/contracts/vault-viewer.ts
+++ b/contracts/vault-viewer.ts
@@ -5,7 +5,7 @@ import { VaultViewerAbi } from 'abi';
 import { getChain, getElUrl } from 'configs';
 
 const VaultViewerAddresses: Record<number, Address> = {
-  [hoodi.id]: '0x069f5f448475c843e099198b5e9F9977bF84FDd0',
+  [hoodi.id]: '0x7155ef6c1487442AB62B2b1c2A87956D3d2dBa36',
 };
 
 export const getVaultViewerContract = () => {


### PR DESCRIPTION
…tract address for hoodi

### Description

**Contract ABI update:**

* Added a new field `totalValueRemainder` of type `uint256` to the `quarantineInfo` struct in the `VaultViewerAbi` definition (`abi/VaultViewer.ts`). [[1]](diffhunk://#diff-25a7f45db9e20ed9b1324e207d08d868a37e1202c7fe33db4b02b5326c1a8cc9R381-R385) [[2]](diffhunk://#diff-25a7f45db9e20ed9b1324e207d08d868a37e1202c7fe33db4b02b5326c1a8cc9R602-R606)

**Configuration update:**

* Updated the `VaultViewerAddresses` mapping to use a new contract address for the `hoodi` chain in `contracts/vault-viewer.ts`.

### Demo

<!-- If thee are visual changes add screenshots or record a [loom](https://www.loom.com/). -->

### Code review notes

<!-- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!-- List all possible edge cases and how to test them. -->

### Checklist:

- [ ]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

