### PR TITLE
fix: use transport-level interception for gas estimation balance over…

### DIFF
--- a/providers/wallet.ts
+++ b/providers/wallet.ts
@@ -5,18 +5,86 @@ import {
   createPublicClient,
   createWalletClient,
   http,
-  maxUint256,
+  type Transport,
   WalletClient,
   createTestClient,
   walletActions,
   publicActions,
 } from 'viem';
-import { estimateGas } from 'viem/actions';
 import { privateKeyToAccount } from 'viem/accounts';
 import { Keystore } from 'ox';
 
 import { envs, getConfig, getChainId, getElUrl, getChain } from 'configs';
 import { createWalletConnectClient } from 'utils';
+
+const MAX_UINT256_HEX =
+  '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+/**
+ * Wraps viem's http() transport to inject a `stateOverride` into every
+ * `eth_estimateGas` RPC call, setting the sender's balance to maxUint256.
+ *
+ * Why: viem's `prepareTransactionRequest` fills `maxFeePerGas` BEFORE
+ * calling `eth_estimateGas`. The node then checks
+ * `balance >= blockGasLimit * maxFeePerGas`, which fails for low-balance
+ * accounts even though the actual TX cost is much lower.
+ *
+ * Operating at the transport level guarantees the override is applied
+ * regardless of how viem resolves its internal action chain (the
+ * `client.extend()` approach does not work because viem's bound methods
+ * close over the original base client and `getAction` short-circuits).
+ *
+ * Falls back to the original call if the RPC does not support
+ * `stateOverride` (geth < 1.13).
+ */
+const balanceAwareTransport = (url: string): Transport => {
+  const baseTransport = http(url);
+
+  return ((params: any) => {
+    const base = baseTransport(params);
+
+    return {
+      ...base,
+      async request(args: { method: string; params?: any }) {
+        if (
+          args.method === 'eth_estimateGas' &&
+          Array.isArray(args.params) &&
+          args.params[0]?.from
+        ) {
+          const from: string = args.params[0].from;
+          const txRequest = args.params[0];
+          const blockTag = args.params[1] ?? 'latest';
+          const existingOverride =
+            (args.params[2] as Record<string, unknown>) ?? {};
+
+          const stateOverride = {
+            ...existingOverride,
+            [from]: { balance: MAX_UINT256_HEX },
+          };
+
+          try {
+            return await base.request({
+              method: 'eth_estimateGas',
+              params: [txRequest, blockTag, stateOverride],
+            });
+          } catch (err: any) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (
+              msg.includes('stateOverride') ||
+              msg.includes('too many arguments') ||
+              msg.includes('invalid argument')
+            ) {
+              return await base.request(args);
+            }
+            throw err;
+          }
+        }
+
+        return base.request(args);
+      },
+    };
+  }) as Transport;
+};
 
 const getPrivateKey = async () => {
   const { PRIVATE_KEY, ACCOUNT_FILE, ACCOUNT_FILE_PASSWORD } = getConfig();
@@ -88,63 +156,6 @@ const PUBLIC_CLIENT_CACHE: {
   [key: number]: ReturnType<typeof createPublicClient>;
 } = {};
 
-/**
- * Returns an estimateGas override that injects a `stateOverride` with
- * maxUint256 balance for the sender during gas estimation only.
- *
- * Why: viem's `prepareTransactionRequest` fills `maxFeePerGas` BEFORE
- * calling `eth_estimateGas`. The node then checks
- * `balance >= blockGasLimit * maxFeePerGas`, which fails for low-balance
- * accounts even though the actual TX cost is much lower.
- *
- * The `baseClient` parameter MUST be the client created before `extend()`,
- * otherwise the override re-enters itself via `prepareTransactionRequest →
- * getAction → override → …` (infinite recursion).
- *
- * Falls back to default estimation if the RPC does not support
- * `stateOverride` (geth < 1.13).
- */
-const balanceAwareEstimateGas = (
-  baseClient: Parameters<typeof estimateGas>[0],
-) => ({
-  estimateGas: async (args: Parameters<typeof estimateGas>[1]) => {
-    const from =
-      typeof args.account === 'string' ? args.account : args.account?.address;
-
-    if (!from) {
-      return await estimateGas(baseClient, args);
-    }
-
-    try {
-      return await estimateGas(baseClient, {
-        ...args,
-        stateOverride: [
-          ...(args.stateOverride ?? []),
-          { address: from, balance: maxUint256 },
-        ],
-      });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      if (
-        msg.includes('stateOverride') ||
-        msg.includes('too many arguments') ||
-        msg.includes('invalid argument')
-      ) {
-        return await estimateGas(baseClient, args);
-      }
-      throw err;
-    }
-  },
-});
-
-/**
- * Public client with balance-aware gas estimation.
- *
- * All contracts are created with `client: publicClient`, so viem uses it
- * for the entire `contract.write` chain (writeContract → sendTransaction →
- * prepareTransactionRequest → estimateGas). The override here covers all
- * contract write paths automatically.
- */
 export const getPublicClient = async () => {
   const chain = await getChain();
 
@@ -153,15 +164,10 @@ export const getPublicClient = async () => {
     return cached as typeof publicClient;
   }
 
-  const baseClient = createPublicClient({
+  const publicClient = createPublicClient({
     chain,
-    transport: http(getElUrl()),
+    transport: balanceAwareTransport(getElUrl()),
   });
-
-  const publicClient = baseClient.extend(() =>
-    balanceAwareEstimateGas(baseClient),
-  );
-
   PUBLIC_CLIENT_CACHE[chain.id] = publicClient;
 
   return publicClient;
@@ -177,25 +183,15 @@ export const getTestClient = async () => {
     .extend(walletActions);
 };
 
-/**
- * Wallet client with the same balance-aware gas estimation override.
- *
- * Covers the `send-tx` command path which uses
- * `walletClient.sendTransaction()` directly (not via contract.write).
- */
 export const getWalletWithAccount = async (): Promise<WalletClient> => {
   const account = await getAccount();
   const chain = await getChain();
 
-  const baseClient = createWalletClient({
+  return createWalletClient({
     account,
     chain,
-    transport: http(getElUrl()),
+    transport: balanceAwareTransport(getElUrl()),
   });
-
-  return baseClient.extend(() =>
-    balanceAwareEstimateGas(baseClient),
-  ) as unknown as WalletClient;
 };
 
 export const getWalletConnectClient = async (): Promise<{

--- a/providers/wallet.ts
+++ b/providers/wallet.ts
@@ -51,7 +51,7 @@ const isStateOverrideError = (err: unknown): boolean => {
  * `stateOverride` (geth < 1.13), and caches the result so subsequent
  * calls skip the failed attempt.
  */
-const balanceAwareTransport = (url: string): Transport => {
+export const balanceAwareTransport = (url: string): Transport => {
   const baseTransport = http(url);
 
   return ((params: any) => {

--- a/providers/wallet.ts
+++ b/providers/wallet.ts
@@ -20,6 +20,19 @@ import { createWalletConnectClient } from 'utils';
 const MAX_UINT256_HEX =
   '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 
+// Cached after the first eth_estimateGas call to avoid a double RPC
+// roundtrip on every subsequent estimation when the node lacks support.
+let nodeSupportsStateOverride: boolean | null = null;
+
+const isStateOverrideError = (err: unknown): boolean => {
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    msg.includes('stateOverride') ||
+    msg.includes('too many arguments') ||
+    msg.includes('invalid argument')
+  );
+};
+
 /**
  * Wraps viem's http() transport to inject a `stateOverride` into every
  * `eth_estimateGas` RPC call, setting the sender's balance to maxUint256.
@@ -35,7 +48,8 @@ const MAX_UINT256_HEX =
  * close over the original base client and `getAction` short-circuits).
  *
  * Falls back to the original call if the RPC does not support
- * `stateOverride` (geth < 1.13).
+ * `stateOverride` (geth < 1.13), and caches the result so subsequent
+ * calls skip the failed attempt.
  */
 const balanceAwareTransport = (url: string): Transport => {
   const baseTransport = http(url);
@@ -51,6 +65,10 @@ const balanceAwareTransport = (url: string): Transport => {
           Array.isArray(args.params) &&
           args.params[0]?.from
         ) {
+          if (nodeSupportsStateOverride === false) {
+            return base.request(args);
+          }
+
           const from: string = args.params[0].from;
           const txRequest = args.params[0];
           const blockTag = args.params[1] ?? 'latest';
@@ -63,17 +81,15 @@ const balanceAwareTransport = (url: string): Transport => {
           };
 
           try {
-            return await base.request({
+            const result = await base.request({
               method: 'eth_estimateGas',
               params: [txRequest, blockTag, stateOverride],
             });
+            nodeSupportsStateOverride = true;
+            return result;
           } catch (err: any) {
-            const msg = err instanceof Error ? err.message : String(err);
-            if (
-              msg.includes('stateOverride') ||
-              msg.includes('too many arguments') ||
-              msg.includes('invalid argument')
-            ) {
+            if (isStateOverrideError(err)) {
+              nodeSupportsStateOverride = false;
               return await base.request(args);
             }
             throw err;

--- a/tests/utils/contract-write-stateoverride.test.ts
+++ b/tests/utils/contract-write-stateoverride.test.ts
@@ -1,0 +1,178 @@
+/**
+ * End-to-end regression test for the balanceAwareTransport fix.
+ *
+ * Verifies that stateOverride is injected into eth_estimateGas even when the
+ * call originates from contract.write[method]() — the path that bypassed the
+ * old client.extend() override due to viem's bound-method closure bug.
+ *
+ * Uses real viem (createWalletClient, getContract, writeContract) with a mock
+ * at the fetch level so we can inspect the exact JSON-RPC payload sent to the
+ * node without needing a live chain.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createWalletClient, getContract, parseAbi, type Chain } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+
+import { balanceAwareTransport } from '../../providers/wallet.js';
+
+const MAX_UINT256_HEX =
+  '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+const TEST_PRIVATE_KEY =
+  '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+
+const MOCK_CHAIN: Chain = {
+  id: 1337,
+  name: 'mocknet',
+  nativeCurrency: { name: 'ETH', symbol: 'ETH', decimals: 18 },
+  rpcUrls: { default: { http: ['http://localhost:8545'] } },
+};
+
+const CONTRACT_ADDRESS = '0x5FbDB2315678afecb367f032d93F642f64180aa3';
+const RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
+
+const ERC20_ABI = parseAbi([
+  'function transfer(address to, uint256 amount) returns (bool)',
+]);
+
+// Helpers -------------------------------------------------------------------
+
+const jsonRpc = (id: number, result: unknown) =>
+  Response.json(
+    { jsonrpc: '2.0', id, result },
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+
+/**
+ * Builds a fetch mock that answers every RPC call viem makes during
+ * contract.write (chainId, nonce, fee estimation, gas estimation, sendTx).
+ *
+ * The capturedEstimateGasCalls array is populated with the full JSON-RPC
+ * body of every eth_estimateGas request so the test can assert on it.
+ */
+const buildFetchMock = (capturedEstimateGasCalls: unknown[]) =>
+  vi.fn(async (_url: string, init?: RequestInit) => {
+    const body = JSON.parse((init?.body as string) ?? '{}');
+    const { id, method } = body;
+
+    switch (method) {
+      case 'eth_chainId': {
+        return jsonRpc(id, `0x${MOCK_CHAIN.id.toString(16)}`);
+      }
+
+      case 'eth_getTransactionCount': {
+        return jsonRpc(id, '0x0');
+      }
+
+      // EIP-1559 fee history used by prepareTransactionRequest
+      case 'eth_feeHistory': {
+        return jsonRpc(id, {
+          baseFeePerGas: ['0x1', '0x1'],
+          gasUsedRatio: [0.5],
+          reward: [['0x1']],
+          oldestBlock: '0x1',
+        });
+      }
+
+      case 'eth_getBlockByNumber': {
+        return jsonRpc(id, {
+          baseFeePerGas: '0x1',
+          number: '0x1',
+          hash: `0x${'a'.repeat(64)}`,
+          transactions: [],
+        });
+      }
+
+      case 'eth_maxPriorityFeePerGas': {
+        return jsonRpc(id, '0x1');
+      }
+
+      case 'eth_estimateGas': {
+        capturedEstimateGasCalls.push(body);
+        return jsonRpc(id, '0x5208');
+      }
+
+      case 'eth_sendRawTransaction': {
+        return jsonRpc(id, `0x${'b'.repeat(64)}`);
+      }
+
+      default: {
+        return jsonRpc(id, null);
+      }
+    }
+  });
+
+// Tests ---------------------------------------------------------------------
+
+describe('contract.write — stateOverride injected via balanceAwareTransport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('eth_estimateGas called by contract.write includes stateOverride for the sender', async () => {
+    const capturedEstimateGasCalls: any[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      buildFetchMock(capturedEstimateGasCalls) as typeof fetch,
+    );
+
+    const account = privateKeyToAccount(TEST_PRIVATE_KEY);
+
+    const client = createWalletClient({
+      account,
+      chain: MOCK_CHAIN,
+      transport: balanceAwareTransport('http://localhost:8545'),
+    });
+
+    const contract = getContract({
+      client,
+      abi: ERC20_ABI,
+      address: CONTRACT_ADDRESS,
+    });
+
+    // This is the exact path that was broken: viem's bound writeContract →
+    // sendTransaction → prepareTransactionRequest → estimateGas never reached
+    // the client.extend() override. With transport-level interception it works.
+    await contract.write.transfer([RECIPIENT, 100n]);
+
+    expect(capturedEstimateGasCalls).toHaveLength(1);
+
+    const estimateGasParams = capturedEstimateGasCalls[0].params;
+    // params[0] = tx object, params[1] = blockTag, params[2] = stateOverride
+    expect(estimateGasParams).toHaveLength(3);
+    expect(estimateGasParams[2]).toMatchObject({
+      [account.address]: { balance: MAX_UINT256_HEX },
+    });
+  });
+
+  it('walletClient.sendTransaction also injects stateOverride (non-contract path)', async () => {
+    const capturedEstimateGasCalls: any[] = [];
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      buildFetchMock(capturedEstimateGasCalls) as typeof fetch,
+    );
+
+    const account = privateKeyToAccount(TEST_PRIVATE_KEY);
+
+    const client = createWalletClient({
+      account,
+      chain: MOCK_CHAIN,
+      transport: balanceAwareTransport('http://localhost:8545'),
+    });
+
+    await client.sendTransaction({
+      to: RECIPIENT,
+      value: 0n,
+    });
+
+    expect(capturedEstimateGasCalls).toHaveLength(1);
+
+    const estimateGasParams = capturedEstimateGasCalls[0].params;
+    expect(estimateGasParams).toHaveLength(3);
+    expect(estimateGasParams[2]).toMatchObject({
+      [account.address]: { balance: MAX_UINT256_HEX },
+    });
+  });
+});

--- a/tests/utils/public-client-gas-estimation.test.ts
+++ b/tests/utils/public-client-gas-estimation.test.ts
@@ -1,31 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { maxUint256 } from 'viem';
 
-const MOCK_ACCOUNT_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+const MAX_UINT256_HEX =
+  '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
 const MOCK_CHAIN = { id: 560048, name: 'hoodi' };
 const MOCK_EL_URL = 'http://localhost:8545';
+const MOCK_FROM = '0x1234567890abcdef1234567890abcdef12345678';
 
-// Track calls to the real estimateGas
-const mockEstimateGas = vi.fn();
-
-vi.mock('viem/actions', () => ({
-  estimateGas: (...args: unknown[]) => mockEstimateGas(...args),
-}));
+// Represents the raw RPC handler underneath the balanceAwareTransport wrapper
+const mockRpcRequest = vi.fn();
 
 vi.mock('viem', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return {
     ...actual,
-    createPublicClient: () => {
-      const base = {
-        chain: MOCK_CHAIN,
-        extend: (fn: (client: unknown) => Record<string, unknown>) => {
-          const extensions = fn(base);
-          for (const key in base) delete (extensions as any)[key];
-          return { ...base, ...extensions };
-        },
-      };
-      return base;
+    // Return a minimal transport factory whose `request` we control
+    http: () => {
+      const factory = Object.assign(
+        () => ({ request: mockRpcRequest }),
+        { config: { key: 'http' }, value: undefined },
+      );
+      return factory;
+    },
+    // Expose the transport's wrapped `request` directly on the client
+    createPublicClient: ({ transport }: any) => {
+      const instance = transport({ chain: MOCK_CHAIN });
+      return { chain: MOCK_CHAIN, request: instance.request };
     },
   };
 });
@@ -53,172 +53,177 @@ vi.mock('ox', () => ({
   Keystore: {},
 }));
 
-describe('getPublicClient gas estimation override', () => {
+/**
+ * Tests for balanceAwareTransport — the transport-level wrapper that injects
+ * stateOverride into every eth_estimateGas RPC call to bypass the node's
+ * balance pre-check.
+ *
+ * We mock viem's http() transport so that `base.request` is our mockRpcRequest,
+ * then call the wrapped `request` directly to verify interception logic.
+ */
+describe('balanceAwareTransport (transport-level gas estimation fix)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should inject stateOverride with maxUint256 balance into estimateGas', async () => {
-    mockEstimateGas.mockResolvedValue(150000n);
+  it('injects stateOverride with max balance into eth_estimateGas', async () => {
+    mockRpcRequest.mockResolvedValue('0x5208');
 
     const { getPublicClient } = await import('../../providers/wallet.js');
     const client = await getPublicClient();
 
-    const args = {
-      to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as const,
-      data: '0x1234' as const,
-      account: { address: MOCK_ACCOUNT_ADDRESS, type: 'local' as const },
-    };
+    await (client as any).request({
+      method: 'eth_estimateGas',
+      params: [{ from: MOCK_FROM, to: '0xdead', data: '0x1234' }],
+    });
 
-    const result = await (client as any).estimateGas(args);
-
-    expect(result).toBe(150000n);
-    expect(mockEstimateGas).toHaveBeenCalledTimes(1);
-
-    const callArgs = mockEstimateGas.mock.calls[0]?.[1];
-    expect(callArgs.stateOverride).toEqual(
-      expect.arrayContaining([
-        { address: MOCK_ACCOUNT_ADDRESS, balance: maxUint256 },
-      ]),
-    );
-  });
-
-  it('should preserve existing stateOverride entries', async () => {
-    mockEstimateGas.mockResolvedValue(200000n);
-
-    const { getPublicClient } = await import('../../providers/wallet.js');
-    const client = await getPublicClient();
-
-    const existingOverride = {
-      address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const,
-      balance: 999n,
-    };
-
-    const args = {
-      to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as const,
-      data: '0x1234' as const,
-      account: { address: MOCK_ACCOUNT_ADDRESS, type: 'local' as const },
-      stateOverride: [existingOverride],
-    };
-
-    await (client as any).estimateGas(args);
-
-    const callArgs = mockEstimateGas.mock.calls[0]?.[1];
-    expect(callArgs.stateOverride).toHaveLength(2);
-    expect(callArgs.stateOverride[0]).toEqual(existingOverride);
-    expect(callArgs.stateOverride[1]).toEqual({
-      address: MOCK_ACCOUNT_ADDRESS,
-      balance: maxUint256,
+    expect(mockRpcRequest).toHaveBeenCalledTimes(1);
+    const rpcCall = mockRpcRequest.mock.calls[0]![0];
+    expect(rpcCall.method).toBe('eth_estimateGas');
+    expect(rpcCall.params).toHaveLength(3);
+    expect(rpcCall.params[0]).toEqual({
+      from: MOCK_FROM,
+      to: '0xdead',
+      data: '0x1234',
+    });
+    expect(rpcCall.params[1]).toBe('latest');
+    expect(rpcCall.params[2]).toEqual({
+      [MOCK_FROM]: { balance: MAX_UINT256_HEX },
     });
   });
 
-  it('should fall back to default estimateGas when stateOverride is unsupported', async () => {
-    mockEstimateGas
+  it('preserves existing stateOverride entries and custom blockTag', async () => {
+    mockRpcRequest.mockResolvedValue('0x5208');
+
+    const { getPublicClient } = await import('../../providers/wallet.js');
+    const client = await getPublicClient();
+
+    const existing = {
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa': { balance: '0x3e7' },
+    };
+
+    await (client as any).request({
+      method: 'eth_estimateGas',
+      params: [{ from: MOCK_FROM, to: '0xdead' }, 'pending', existing],
+    });
+
+    const rpcCall = mockRpcRequest.mock.calls[0]![0];
+    expect(rpcCall.params[1]).toBe('pending');
+    expect(rpcCall.params[2]).toEqual({
+      ...existing,
+      [MOCK_FROM]: { balance: MAX_UINT256_HEX },
+    });
+  });
+
+  it('falls back when RPC rejects stateOverride', async () => {
+    mockRpcRequest
       .mockRejectedValueOnce(new Error('invalid argument 2: stateOverride'))
-      .mockResolvedValueOnce(100000n);
+      .mockResolvedValueOnce('0x5208');
 
     const { getPublicClient } = await import('../../providers/wallet.js');
     const client = await getPublicClient();
 
-    const args = {
-      to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as const,
-      data: '0x1234' as const,
-      account: { address: MOCK_ACCOUNT_ADDRESS, type: 'local' as const },
-    };
+    const result = await (client as any).request({
+      method: 'eth_estimateGas',
+      params: [{ from: MOCK_FROM, to: '0xdead' }],
+    });
 
-    const result = await (client as any).estimateGas(args);
+    expect(result).toBe('0x5208');
+    expect(mockRpcRequest).toHaveBeenCalledTimes(2);
 
-    expect(result).toBe(100000n);
-    expect(mockEstimateGas).toHaveBeenCalledTimes(2);
-
-    // Second call should NOT have stateOverride
-    const fallbackArgs = mockEstimateGas.mock.calls[1]?.[1];
-    expect(fallbackArgs.stateOverride).toBeUndefined();
+    // Second call: original args without stateOverride
+    const fallbackCall = mockRpcRequest.mock.calls[1]![0];
+    expect(fallbackCall.params).toHaveLength(1);
   });
 
-  it('should fall back when RPC returns "too many arguments"', async () => {
-    mockEstimateGas
+  it('falls back on "too many arguments"', async () => {
+    mockRpcRequest
       .mockRejectedValueOnce(new Error('too many arguments, want at most 2'))
-      .mockResolvedValueOnce(100000n);
+      .mockResolvedValueOnce('0x5208');
 
     const { getPublicClient } = await import('../../providers/wallet.js');
     const client = await getPublicClient();
 
-    const args = {
-      to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as const,
-      data: '0x1234' as const,
-      account: { address: MOCK_ACCOUNT_ADDRESS, type: 'local' as const },
-    };
+    const result = await (client as any).request({
+      method: 'eth_estimateGas',
+      params: [{ from: MOCK_FROM, to: '0xdead' }],
+    });
 
-    const result = await (client as any).estimateGas(args);
-
-    expect(result).toBe(100000n);
-    expect(mockEstimateGas).toHaveBeenCalledTimes(2);
+    expect(result).toBe('0x5208');
+    expect(mockRpcRequest).toHaveBeenCalledTimes(2);
   });
 
-  it('should re-throw real contract errors (not swallow them)', async () => {
-    const revertError = new Error(
-      'execution reverted: ERC20: transfer amount exceeds balance',
-    );
-    mockEstimateGas.mockRejectedValue(revertError);
+  it('falls back on "invalid argument"', async () => {
+    mockRpcRequest
+      .mockRejectedValueOnce(new Error('invalid argument'))
+      .mockResolvedValueOnce('0x5208');
 
     const { getPublicClient } = await import('../../providers/wallet.js');
     const client = await getPublicClient();
 
-    const args = {
-      to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as const,
-      data: '0x1234' as const,
-      account: { address: MOCK_ACCOUNT_ADDRESS, type: 'local' as const },
-    };
+    const result = await (client as any).request({
+      method: 'eth_estimateGas',
+      params: [{ from: MOCK_FROM, to: '0xdead' }],
+    });
 
-    await expect((client as any).estimateGas(args)).rejects.toThrow(
-      'execution reverted',
+    expect(result).toBe('0x5208');
+    expect(mockRpcRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-throws real contract errors (not swallowed)', async () => {
+    mockRpcRequest.mockRejectedValue(
+      new Error('execution reverted: ERC20: transfer amount exceeds balance'),
     );
+
+    const { getPublicClient } = await import('../../providers/wallet.js');
+    const client = await getPublicClient();
+
+    await expect(
+      (client as any).request({
+        method: 'eth_estimateGas',
+        params: [{ from: MOCK_FROM, to: '0xdead' }],
+      }),
+    ).rejects.toThrow('execution reverted');
 
     // Should NOT retry — only 1 call
-    expect(mockEstimateGas).toHaveBeenCalledTimes(1);
+    expect(mockRpcRequest).toHaveBeenCalledTimes(1);
   });
 
-  it('should skip override when no account is provided', async () => {
-    mockEstimateGas.mockResolvedValue(21000n);
+  it('skips override when no from address in params', async () => {
+    mockRpcRequest.mockResolvedValue('0x5208');
 
     const { getPublicClient } = await import('../../providers/wallet.js');
     const client = await getPublicClient();
 
-    const args = {
-      to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as const,
-      value: 0n,
-      // no account
-    };
+    await (client as any).request({
+      method: 'eth_estimateGas',
+      params: [{ to: '0xdead', data: '0x1234' }],
+    });
 
-    const result = await (client as any).estimateGas(args);
-
-    expect(result).toBe(21000n);
-    expect(mockEstimateGas).toHaveBeenCalledTimes(1);
-
-    // Should call without stateOverride since no account
-    const callArgs = mockEstimateGas.mock.calls[0]?.[1];
-    expect(callArgs.stateOverride).toBeUndefined();
+    expect(mockRpcRequest).toHaveBeenCalledTimes(1);
+    // Passed through unchanged — no stateOverride injected
+    const rpcCall = mockRpcRequest.mock.calls[0]![0];
+    expect(rpcCall).toEqual({
+      method: 'eth_estimateGas',
+      params: [{ to: '0xdead', data: '0x1234' }],
+    });
   });
 
-  it('should handle string account address', async () => {
-    mockEstimateGas.mockResolvedValue(150000n);
+  it('passes non-estimateGas calls through unchanged', async () => {
+    mockRpcRequest.mockResolvedValue('0x1');
 
     const { getPublicClient } = await import('../../providers/wallet.js');
     const client = await getPublicClient();
 
-    const differentAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
-    const args = {
-      to: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as const,
-      data: '0x1234' as const,
-      account: differentAddress,
-    };
+    await (client as any).request({
+      method: 'eth_blockNumber',
+      params: [],
+    });
 
-    await (client as any).estimateGas(args);
-
-    const callArgs = mockEstimateGas.mock.calls[0]?.[1];
-    expect(callArgs.stateOverride).toEqual([
-      { address: differentAddress, balance: maxUint256 },
-    ]);
+    expect(mockRpcRequest).toHaveBeenCalledTimes(1);
+    expect(mockRpcRequest.mock.calls[0]![0]).toEqual({
+      method: 'eth_blockNumber',
+      params: [],
+    });
   });
 });

--- a/tests/utils/public-client-gas-estimation.test.ts
+++ b/tests/utils/public-client-gas-estimation.test.ts
@@ -290,10 +290,10 @@ describe('balanceAwareTransport (transport-level gas estimation fix)', () => {
 
     expect(mockRpcRequest).toHaveBeenCalledTimes(3); // 2 from first + 1 direct
     // Third RPC call: original args, no stateOverride
-    const typedCalls = mockRpcRequest.mock.calls as Array<
-      [{ params: unknown[] }]
-    >;
-    const directCall = typedCalls[2][0];
+    // .at(-1) is safe here — we just asserted toHaveBeenCalledTimes(3)
+    const directCall = (
+      mockRpcRequest.mock.calls.at(-1) as [{ params: unknown[] }]
+    )[0];
     expect(directCall.params).toHaveLength(1);
     expect(directCall.params[0]).toEqual({ from: MOCK_FROM, to: '0xbeef' });
   });

--- a/tests/utils/public-client-gas-estimation.test.ts
+++ b/tests/utils/public-client-gas-estimation.test.ts
@@ -60,10 +60,14 @@ vi.mock('ox', () => ({
  *
  * We mock viem's http() transport so that `base.request` is our mockRpcRequest,
  * then call the wrapped `request` directly to verify interception logic.
+ *
+ * vi.resetModules() in beforeEach ensures each test gets a fresh module with
+ * a clean nodeSupportsStateOverride cache.
  */
 describe('balanceAwareTransport (transport-level gas estimation fix)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.resetModules();
   });
 
   it('injects stateOverride with max balance into eth_estimateGas', async () => {
@@ -225,5 +229,59 @@ describe('balanceAwareTransport (transport-level gas estimation fix)', () => {
       method: 'eth_blockNumber',
       params: [],
     });
+  });
+
+  it('caches stateOverride support after first successful call', async () => {
+    mockRpcRequest.mockResolvedValue('0x5208');
+
+    const { getPublicClient } = await import('../../providers/wallet.js');
+    const client = await getPublicClient();
+
+    // First call — probes stateOverride support
+    await (client as any).request({
+      method: 'eth_estimateGas',
+      params: [{ from: MOCK_FROM, to: '0xdead' }],
+    });
+
+    // Second call — should still inject stateOverride (cached: supported)
+    await (client as any).request({
+      method: 'eth_estimateGas',
+      params: [{ from: MOCK_FROM, to: '0xbeef' }],
+    });
+
+    expect(mockRpcRequest).toHaveBeenCalledTimes(2);
+    // Both calls include stateOverride (3 params each)
+    expect(mockRpcRequest.mock.calls[0]![0].params).toHaveLength(3);
+    expect(mockRpcRequest.mock.calls[1]![0].params).toHaveLength(3);
+  });
+
+  it('skips stateOverride on subsequent calls after fallback (cached: unsupported)', async () => {
+    // First call: stateOverride fails → fallback
+    mockRpcRequest
+      .mockRejectedValueOnce(new Error('too many arguments, want at most 2'))
+      .mockResolvedValueOnce('0x5208');
+
+    const { getPublicClient } = await import('../../providers/wallet.js');
+    const client = await getPublicClient();
+
+    await (client as any).request({
+      method: 'eth_estimateGas',
+      params: [{ from: MOCK_FROM, to: '0xdead' }],
+    });
+
+    expect(mockRpcRequest).toHaveBeenCalledTimes(2); // try + fallback
+
+    // Second call: should go directly to original (no stateOverride attempt)
+    mockRpcRequest.mockResolvedValueOnce('0x7530');
+    await (client as any).request({
+      method: 'eth_estimateGas',
+      params: [{ from: MOCK_FROM, to: '0xbeef' }],
+    });
+
+    expect(mockRpcRequest).toHaveBeenCalledTimes(3); // 2 from first + 1 direct
+    // Third RPC call: original args, no stateOverride
+    const directCall = mockRpcRequest.mock.calls[2]![0];
+    expect(directCall.params).toHaveLength(1);
+    expect(directCall.params[0]).toEqual({ from: MOCK_FROM, to: '0xbeef' });
   });
 });

--- a/tests/utils/public-client-gas-estimation.test.ts
+++ b/tests/utils/public-client-gas-estimation.test.ts
@@ -16,10 +16,10 @@ vi.mock('viem', async (importOriginal) => {
     ...actual,
     // Return a minimal transport factory whose `request` we control
     http: () => {
-      const factory = Object.assign(
-        () => ({ request: mockRpcRequest }),
-        { config: { key: 'http' }, value: undefined },
-      );
+      const factory = Object.assign(() => ({ request: mockRpcRequest }), {
+        config: { key: 'http' },
+        value: undefined,
+      });
       return factory;
     },
     // Expose the transport's wrapped `request` directly on the client
@@ -82,7 +82,9 @@ describe('balanceAwareTransport (transport-level gas estimation fix)', () => {
     });
 
     expect(mockRpcRequest).toHaveBeenCalledTimes(1);
-    const rpcCall = mockRpcRequest.mock.calls[0]![0];
+    const [[rpcCall]] = mockRpcRequest.mock.calls as [
+      [{ method: string; params: unknown[] }],
+    ];
     expect(rpcCall.method).toBe('eth_estimateGas');
     expect(rpcCall.params).toHaveLength(3);
     expect(rpcCall.params[0]).toEqual({
@@ -111,7 +113,7 @@ describe('balanceAwareTransport (transport-level gas estimation fix)', () => {
       params: [{ from: MOCK_FROM, to: '0xdead' }, 'pending', existing],
     });
 
-    const rpcCall = mockRpcRequest.mock.calls[0]![0];
+    const [[rpcCall]] = mockRpcRequest.mock.calls as [[{ params: unknown[] }]];
     expect(rpcCall.params[1]).toBe('pending');
     expect(rpcCall.params[2]).toEqual({
       ...existing,
@@ -136,7 +138,10 @@ describe('balanceAwareTransport (transport-level gas estimation fix)', () => {
     expect(mockRpcRequest).toHaveBeenCalledTimes(2);
 
     // Second call: original args without stateOverride
-    const fallbackCall = mockRpcRequest.mock.calls[1]![0];
+    const [, [fallbackCall]] = mockRpcRequest.mock.calls as [
+      [unknown],
+      [{ params: unknown[] }],
+    ];
     expect(fallbackCall.params).toHaveLength(1);
   });
 
@@ -206,7 +211,7 @@ describe('balanceAwareTransport (transport-level gas estimation fix)', () => {
 
     expect(mockRpcRequest).toHaveBeenCalledTimes(1);
     // Passed through unchanged — no stateOverride injected
-    const rpcCall = mockRpcRequest.mock.calls[0]![0];
+    const [[rpcCall]] = mockRpcRequest.mock.calls as [[unknown]];
     expect(rpcCall).toEqual({
       method: 'eth_estimateGas',
       params: [{ to: '0xdead', data: '0x1234' }],
@@ -225,7 +230,8 @@ describe('balanceAwareTransport (transport-level gas estimation fix)', () => {
     });
 
     expect(mockRpcRequest).toHaveBeenCalledTimes(1);
-    expect(mockRpcRequest.mock.calls[0]![0]).toEqual({
+    const [[rpcCall]] = mockRpcRequest.mock.calls as [[unknown]];
+    expect(rpcCall).toEqual({
       method: 'eth_blockNumber',
       params: [],
     });
@@ -251,8 +257,12 @@ describe('balanceAwareTransport (transport-level gas estimation fix)', () => {
 
     expect(mockRpcRequest).toHaveBeenCalledTimes(2);
     // Both calls include stateOverride (3 params each)
-    expect(mockRpcRequest.mock.calls[0]![0].params).toHaveLength(3);
-    expect(mockRpcRequest.mock.calls[1]![0].params).toHaveLength(3);
+    const [[firstCall], [secondCall]] = mockRpcRequest.mock.calls as [
+      [{ params: unknown[] }],
+      [{ params: unknown[] }],
+    ];
+    expect(firstCall.params).toHaveLength(3);
+    expect(secondCall.params).toHaveLength(3);
   });
 
   it('skips stateOverride on subsequent calls after fallback (cached: unsupported)', async () => {
@@ -280,7 +290,10 @@ describe('balanceAwareTransport (transport-level gas estimation fix)', () => {
 
     expect(mockRpcRequest).toHaveBeenCalledTimes(3); // 2 from first + 1 direct
     // Third RPC call: original args, no stateOverride
-    const directCall = mockRpcRequest.mock.calls[2]![0];
+    const typedCalls = mockRpcRequest.mock.calls as Array<
+      [{ params: unknown[] }]
+    >;
+    const directCall = typedCalls[2][0];
     expect(directCall.params).toHaveLength(1);
     expect(directCall.params[0]).toEqual({ from: MOCK_FROM, to: '0xbeef' });
   });


### PR DESCRIPTION
…ride

Replace client.extend() approach with a custom transport wrapper (balanceAwareTransport) that intercepts eth_estimateGas at the raw RPC level, injecting stateOverride with maxUint256 balance for the sender.

The extend() approach does not work for contract.write paths because viem's getAction finds bound methods from the base client and short-circuits, never reaching the override.

Transport-level interception guarantees the stateOverride is applied regardless of how viem resolves its internal action chain. Falls back gracefully for nodes that don't support stateOverride (geth < 1.13).

### Description

<!-- Briefly note most valuable changes in what you did and why we need it, even if the task was described in detail in the task tracker. -->

<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Demo

<!-- If thee are visual changes add screenshots or record a [loom](https://www.loom.com/). -->

### Code review notes

<!-- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!-- List all possible edge cases and how to test them. -->

### Checklist:

- [ ]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

