### PR TITLE
fix: limit IPFS content size to prevent OOM DoS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ cache/*
 # lsv-web-terminal
 lsv-web-terminal
 .anvil.pid
+
+AGENTS.md
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ PRIVATE_KEY=0x
 # Note: WALLET_CONNECT_PROJECT_ID is NOT a secret. It is a public identifier
 # of the application using WalletConnect.
 WALLET_CONNECT_PROJECT_ID=ee928c025792b10a6daa97d85328c433
+
+# IPFS (optional)
+# Maximum size, in bytes, of content fetched from an IPFS gateway. Oversized
+# objects are rejected before they are buffered into memory, guarding against
+# out-of-memory DoS from a hostile or mistaken CID. Defaults to 20 MiB
+# (20971520). Applications embedding the CLI as a package can also override
+# this per call via the `maxBytes` argument of the fetch helpers.
+# IPFS_MAX_CONTENT_BYTES=20971520
 ```
 
 If you plan to manage contracts, **PRIVATE_KEY** (or an encrypted account file) is required for write operations.

--- a/tests/utils/ipfs-security.test.ts
+++ b/tests/utils/ipfs-security.test.ts
@@ -27,9 +27,21 @@ vi.mock('../../utils/logging/console.js', () => ({
   logInfo: vi.fn(),
   logTable: vi.fn(),
 }));
+// Force a cache miss so the cached path falls through to a real fetch,
+// and keep the test from touching the disk.
+vi.mock('node:fs/promises', () => ({
+  default: {
+    mkdir: vi.fn(async () => {}),
+    readFile: vi.fn(async () => {
+      throw new Error('ENOENT');
+    }),
+    writeFile: vi.fn(async () => {}),
+  },
+}));
 
 import * as ipfs from '../../utils/ipfs.js';
 import type { Mock } from 'vitest';
+import { streamOf } from './stream-helpers.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -65,7 +77,7 @@ describe('IPFS SSRF guards (H2/H3)', () => {
   test('fetchIPFSDirect allows https gateway', async () => {
     (globalThis.fetch as Mock).mockResolvedValueOnce({
       ok: true,
-      text: async () => '{"x":1}',
+      body: streamOf(new TextEncoder().encode('{"x":1}')),
     });
     const result = await ipfs.fetchIPFSDirect({
       cid: 'abc',
@@ -77,7 +89,7 @@ describe('IPFS SSRF guards (H2/H3)', () => {
   test('fetchIPFSDirect allows http gateway', async () => {
     (globalThis.fetch as Mock).mockResolvedValueOnce({
       ok: true,
-      text: async () => '{"y":2}',
+      body: streamOf(new TextEncoder().encode('{"y":2}')),
     });
     const result = await ipfs.fetchIPFSDirect({
       cid: 'abc',
@@ -114,6 +126,178 @@ describe('IPFS SSRF guards (H2/H3)', () => {
       fileContent: '{}',
     });
     expect(result).toEqual({ IpfsHash: 'Qm123' });
+  });
+});
+
+describe('IPFS content size limit', () => {
+  const headersOf = (h: Record<string, string>) => ({
+    get: (k: string) => h[k.toLowerCase()] ?? null,
+  });
+
+  // Stub the next fetch() with an ok response carrying the given body and,
+  // optionally, a Content-Length header.
+  const mockFetchOnce = (body: unknown, contentLength?: number) => {
+    const headers: Record<string, string> =
+      contentLength === undefined
+        ? {}
+        : { 'content-length': String(contentLength) };
+
+    (globalThis.fetch as Mock).mockResolvedValueOnce({
+      ok: true,
+      headers: headersOf(headers),
+      body,
+    });
+  };
+
+  // Run fn with IPFS_MAX_CONTENT_BYTES set, always restoring the prior value.
+  const withEnvLimit = async (value: number, fn: () => Promise<void>) => {
+    const prev = process.env.IPFS_MAX_CONTENT_BYTES;
+    process.env.IPFS_MAX_CONTENT_BYTES = String(value);
+
+    try {
+      await fn();
+    } finally {
+      if (prev === undefined) delete process.env.IPFS_MAX_CONTENT_BYTES;
+      else process.env.IPFS_MAX_CONTENT_BYTES = prev;
+    }
+  };
+
+  test('rejects on Content-Length over limit without reading body', async () => {
+    const getReader = vi.fn(() => {
+      throw new Error(
+        'body must not be read when Content-Length exceeds limit',
+      );
+    });
+    mockFetchOnce({ getReader }, 2_785_017_856);
+
+    await expect(
+      ipfs.fetchIPFSBuffer({ cid: 'abc', maxBytes: 20 * 1024 * 1024 }),
+    ).rejects.toThrow(/too large|exceeds/i);
+    expect(getReader).not.toHaveBeenCalled();
+  });
+
+  test('aborts streaming when body exceeds limit (no Content-Length)', async () => {
+    mockFetchOnce(streamOf(new Uint8Array(300 * 1024).fill(7)));
+
+    await expect(
+      ipfs.fetchIPFSBuffer({ cid: 'abc', maxBytes: 128 * 1024 }),
+    ).rejects.toThrow(/exceeds/i);
+  });
+
+  test('returns content within the limit', async () => {
+    const payload = new Uint8Array([1, 2, 3, 4, 5]);
+    mockFetchOnce(streamOf(payload), payload.byteLength);
+
+    const res = await ipfs.fetchIPFSBuffer({
+      cid: 'abc',
+      maxBytes: 20 * 1024 * 1024,
+    });
+    expect(res).toEqual(payload);
+  });
+
+  test('fails closed when the response has no body', async () => {
+    mockFetchOnce(null);
+
+    await expect(ipfs.fetchIPFSBuffer({ cid: 'abc' })).rejects.toThrow(
+      /no readable body/i,
+    );
+  });
+
+  test('fetchIPFSDirect aborts streaming when body exceeds limit', async () => {
+    mockFetchOnce(streamOf(new TextEncoder().encode('x'.repeat(300 * 1024))));
+
+    await expect(
+      ipfs.fetchIPFSDirect({ cid: 'abc', maxBytes: 128 * 1024 }),
+    ).rejects.toThrow(/exceeds/i);
+  });
+
+  test('enforces the 20MB default when no override / env is set', async () => {
+    mockFetchOnce({ getReader: vi.fn() }, 20 * 1024 * 1024 + 1);
+
+    await expect(ipfs.fetchIPFSBuffer({ cid: 'abc' })).rejects.toThrow(
+      `limit of ${20 * 1024 * 1024} bytes`,
+    );
+  });
+
+  test('IPFS_MAX_CONTENT_BYTES env overrides the default', async () => {
+    await withEnvLimit(64 * 1024, async () => {
+      mockFetchOnce({ getReader: vi.fn() }, 128 * 1024);
+
+      await expect(ipfs.fetchIPFSBuffer({ cid: 'abc' })).rejects.toThrow(
+        `limit of ${64 * 1024} bytes`,
+      );
+    });
+  });
+
+  test('explicit maxBytes arg takes priority over env', async () => {
+    await withEnvLimit(1024 * 1024 * 1024, async () => {
+      mockFetchOnce({ getReader: vi.fn() }, 256 * 1024);
+
+      await expect(
+        ipfs.fetchIPFSBuffer({ cid: 'abc', maxBytes: 128 * 1024 }),
+      ).rejects.toThrow(`limit of ${128 * 1024} bytes`);
+    });
+  });
+
+  test('streaming enforces limit even when Content-Length lies', async () => {
+    // header claims 1 KiB, body is actually 300 KiB
+    mockFetchOnce(streamOf(new Uint8Array(300 * 1024).fill(9)), 1024);
+
+    await expect(
+      ipfs.fetchIPFSBuffer({ cid: 'abc', maxBytes: 128 * 1024 }),
+    ).rejects.toThrow(`exceeds size limit of ${128 * 1024} bytes`);
+  });
+
+  test('accepts content exactly at the limit, rejects one byte over', async () => {
+    const limit = 200 * 1024;
+
+    mockFetchOnce(streamOf(new Uint8Array(limit).fill(1)));
+    const ok = await ipfs.fetchIPFSBuffer({ cid: 'abc', maxBytes: limit });
+    expect(ok.byteLength).toBe(limit);
+
+    mockFetchOnce(streamOf(new Uint8Array(limit + 1).fill(1)));
+    await expect(
+      ipfs.fetchIPFSBuffer({ cid: 'abc', maxBytes: limit }),
+    ).rejects.toThrow(`exceeds size limit of ${limit} bytes`);
+  });
+
+  test('reassembles a multi-chunk stream in order under the limit', async () => {
+    const chunkSize = 64 * 1024;
+    const parts = [0, 1, 2, 3, 4].map((i) =>
+      new Uint8Array(chunkSize).fill(i + 1),
+    );
+    const payload = new Uint8Array(chunkSize * parts.length);
+    for (const [i, p] of parts.entries()) {
+      payload.set(p, i * chunkSize);
+    }
+
+    mockFetchOnce(streamOf(payload, chunkSize)); // one read() per chunk
+
+    const res = await ipfs.fetchIPFSBuffer({
+      cid: 'abc',
+      maxBytes: 20 * 1024 * 1024,
+    });
+    expect(res).toEqual(payload); // order + bytes preserved across chunks
+  });
+
+  // Threading: maxBytes must survive every hop of the public API, not just
+  // the leaf fetchIPFSBuffer. A dropped arg at any wrapper = silent bypass.
+  test('fetchIPFS (default cached path) threads maxBytes end-to-end', async () => {
+    mockFetchOnce(streamOf(new Uint8Array(300 * 1024).fill(3)));
+
+    // cache default true -> WithCacheAndVerify -> DirectAndVerify -> Buffer
+    await expect(
+      ipfs.fetchIPFS({ cid: 'abc', maxBytes: 128 * 1024 }),
+    ).rejects.toThrow(`exceeds size limit of ${128 * 1024} bytes`);
+  });
+
+  test('fetchIPFS (no-cache path) threads maxBytes end-to-end', async () => {
+    mockFetchOnce(streamOf(new Uint8Array(300 * 1024).fill(4)));
+
+    // cache false -> DirectAndVerify -> Buffer
+    await expect(
+      ipfs.fetchIPFS({ cid: 'abc', maxBytes: 128 * 1024 }, false),
+    ).rejects.toThrow(`exceeds size limit of ${128 * 1024} bytes`);
   });
 });
 

--- a/tests/utils/ipfs.test.ts
+++ b/tests/utils/ipfs.test.ts
@@ -29,6 +29,7 @@ vi.mock('../../utils/logging/console.js', () => ({
 import { CID } from 'multiformats/cid';
 import * as ipfs from '../../utils/ipfs.js';
 import type { Mock } from 'vitest';
+import { streamOf } from './stream-helpers.js';
 
 const fakeCid = CID.parse(
   'bafkreigh2akiscaildcjk2d6gtrevhb7f7esg6k4t4u5p4sqkgfa6vlriu',
@@ -54,13 +55,12 @@ describe('ipfs helpers', () => {
   test('fetchIPFS parses JSON response', async () => {
     const jsonData = '{"foo":1}';
     const encoder = new TextEncoder();
-    const buffer = encoder.encode(jsonData).buffer;
+    const bytes = encoder.encode(jsonData);
     const testCid = fakeCid.toString();
 
     (globalThis.fetch as Mock).mockResolvedValueOnce({
       ok: true,
-      text: async () => jsonData,
-      arrayBuffer: async () => buffer,
+      body: streamOf(bytes),
     });
 
     // Mock importer for calculateIPFSAddCID
@@ -87,14 +87,14 @@ describe('ipfs helpers', () => {
   });
 
   test('fetchIPFSBuffer returns buffer', async () => {
-    const buf = new ArrayBuffer(4);
+    const bytes = new Uint8Array(4);
     (globalThis.fetch as Mock).mockResolvedValueOnce({
       ok: true,
-      arrayBuffer: async () => buf,
+      body: streamOf(bytes),
     });
     const res = await ipfs.fetchIPFSBuffer({ cid: 'abc' });
     expect(globalThis.fetch).toHaveBeenCalledWith('https://ipfs.io/ipfs/abc');
-    expect(res).toEqual(new Uint8Array(buf));
+    expect(res).toEqual(bytes);
   });
 
   test('calculateIPFSAddCID returns last CID', async () => {
@@ -120,7 +120,7 @@ describe('ipfs helpers', () => {
     // Mock fetch to prevent actual network calls
     (globalThis.fetch as Mock).mockResolvedValueOnce({
       ok: true,
-      arrayBuffer: async () => fileContent.buffer,
+      body: streamOf(fileContent),
     });
 
     importer.mockImplementationOnce(async function* () {
@@ -145,7 +145,7 @@ describe('ipfs helpers', () => {
     // Mock fetch to return the file content
     (globalThis.fetch as Mock).mockResolvedValueOnce({
       ok: true,
-      arrayBuffer: async () => fileContent.buffer,
+      body: streamOf(fileContent),
     });
 
     // Mock importer to return different CID

--- a/tests/utils/stream-helpers.ts
+++ b/tests/utils/stream-helpers.ts
@@ -1,0 +1,11 @@
+// Build a ReadableStream response body from bytes, chunked so tests exercise
+// multi-read streaming. Default chunk keeps small payloads a single read.
+export const streamOf = (bytes: Uint8Array, chunkSize = 64 * 1024) =>
+  new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        controller.enqueue(bytes.slice(i, i + chunkSize));
+      }
+      controller.close();
+    },
+  });

--- a/utils/env.ts
+++ b/utils/env.ts
@@ -1,0 +1,9 @@
+// Parse an integer from an env var, falling back when unset or invalid.
+export const parseEnvInt = (
+  raw: string | undefined,
+  fallback: number,
+): number => {
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+};

--- a/utils/ipfs.ts
+++ b/utils/ipfs.ts
@@ -7,27 +7,124 @@ import path from 'node:path';
 
 import { logInfo, logTable } from './logging/console.js';
 import { assertSafeUrl } from './data-validators.js';
+import { parseEnvInt } from './env.js';
 
 export const IPFS_GATEWAY = 'https://ipfs.io/ipfs';
+
+// Max IPFS content size — guards against OOM from an oversized CID.
+// Override: maxBytes arg > IPFS_MAX_CONTENT_BYTES env > this default.
+export const DEFAULT_IPFS_MAX_CONTENT_BYTES = 20 * 1024 * 1024;
 
 export type BigNumberType = 'bigint' | 'string';
 export type ReportFetchArgs = {
   cid: string;
   gateway?: string;
   bigNumberType?: BigNumberType;
+  maxBytes?: number;
 };
 
 const IPFS_CACHE_DIR = path.resolve('ipfs-cache');
+
+// arg > env > default
+const resolveMaxBytes = (override?: number): number => {
+  if (
+    typeof override === 'number' &&
+    Number.isFinite(override) &&
+    override > 0
+  ) {
+    return override;
+  }
+
+  return Math.max(
+    1,
+    parseEnvInt(
+      process.env.IPFS_MAX_CONTENT_BYTES,
+      DEFAULT_IPFS_MAX_CONTENT_BYTES,
+    ),
+  );
+};
+
+// Cheap pre-check. Header may be absent or lie — streaming is the real limit.
+const assertContentLengthWithinLimit = (
+  response: Response,
+  maxBytes: number,
+): void => {
+  const declared = Number(response.headers?.get('content-length'));
+
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new Error(
+      `IPFS content too large: ${declared} bytes exceeds limit of ${maxBytes} bytes`,
+    );
+  }
+};
+
+// Join collected byte chunks into a single buffer.
+const concatChunks = (chunks: Uint8Array[], total: number): Uint8Array => {
+  const out = new Uint8Array(total);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return out;
+};
+
+// Read in chunks, abort once total exceeds maxBytes (before full buffering).
+const streamBodyWithLimit = async (
+  body: ReadableStream<Uint8Array>,
+  maxBytes: number,
+): Promise<Uint8Array> => {
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new Error(`IPFS content exceeds size limit of ${maxBytes} bytes`);
+      }
+
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock?.();
+  }
+
+  return concatChunks(chunks, total);
+};
+
+// Streaming is the real limit; Content-Length is just an early reject.
+// Fail closed if there's no body — a real fetch always has one for content.
+const readBodyWithLimit = async (
+  response: Response,
+  maxBytes: number,
+): Promise<Uint8Array> => {
+  assertContentLengthWithinLimit(response, maxBytes);
+
+  if (!response.body) {
+    throw new Error('IPFS response has no readable body');
+  }
+
+  return streamBodyWithLimit(response.body, maxBytes);
+};
 
 export const fetchIPFS = async <T>(
   args: ReportFetchArgs,
   cache = true,
 ): Promise<T> => {
-  const { cid, gateway = IPFS_GATEWAY } = args;
+  const { cid, gateway = IPFS_GATEWAY, maxBytes } = args;
 
-  if (cache) return fetchIPFSWithCacheAndVerify<T>(cid, gateway);
+  if (cache) return fetchIPFSWithCacheAndVerify<T>(cid, gateway, maxBytes);
 
-  const { json } = await fetchIPFSDirectAndVerify<T>(cid, gateway);
+  const { json } = await fetchIPFSDirectAndVerify<T>(cid, gateway, maxBytes);
   return json;
 };
 
@@ -35,6 +132,7 @@ export const fetchIPFS = async <T>(
 export const fetchIPFSDirect = async <T>(args: ReportFetchArgs): Promise<T> => {
   const { cid, gateway = IPFS_GATEWAY, bigNumberType = 'string' } = args;
   assertSafeUrl(gateway, 'IPFS gateway');
+  const maxBytes = resolveMaxBytes(args.maxBytes);
   const ipfsUrl = `${gateway}/${cid}`;
 
   logInfo('Fetching content from', ipfsUrl);
@@ -44,7 +142,9 @@ export const fetchIPFSDirect = async <T>(args: ReportFetchArgs): Promise<T> => {
     throw new Error(`Failed to fetch IPFS content: ${response.statusText}`);
   }
 
-  const raw = await response.text();
+  const raw = new TextDecoder().decode(
+    await readBodyWithLimit(response, maxBytes),
+  );
   const params =
     bigNumberType === 'bigint'
       ? { useNativeBigInt: true }
@@ -60,6 +160,7 @@ export const fetchIPFSBuffer = async (
 ): Promise<Uint8Array> => {
   const { cid, gateway = IPFS_GATEWAY } = args;
   assertSafeUrl(gateway, 'IPFS gateway');
+  const maxBytes = resolveMaxBytes(args.maxBytes);
   const ipfsUrl = `${gateway}/${cid}`;
   logInfo('Fetching content from', ipfsUrl);
 
@@ -67,8 +168,7 @@ export const fetchIPFSBuffer = async (
   if (!response.ok) {
     throw new Error(`Failed to fetch IPFS content: ${response.statusText}`);
   }
-  const buffer = await response.arrayBuffer();
-  return new Uint8Array(buffer);
+  return readBodyWithLimit(response, maxBytes);
 };
 
 // Recalculate CID using full UnixFS logic (like `ipfs add`)
@@ -100,6 +200,7 @@ export const calculateIPFSAddCID = async (
 export const fetchIPFSDirectAndVerify = async <T>(
   cid: string,
   gateway = IPFS_GATEWAY,
+  maxBytes?: number,
 ): Promise<{ json: T; fileContent: Uint8Array }> => {
   let originalCID: CID;
   try {
@@ -108,7 +209,7 @@ export const fetchIPFSDirectAndVerify = async <T>(
     throw new Error(`Invalid IPFS CID: ${cid}`);
   }
 
-  const fileContent = await fetchIPFSBuffer({ cid, gateway });
+  const fileContent = await fetchIPFSBuffer({ cid, gateway, maxBytes });
   const calculatedCID = await calculateIPFSAddCID(
     fileContent,
     originalCID.version,
@@ -140,6 +241,7 @@ export const fetchIPFSDirectAndVerify = async <T>(
 export const fetchIPFSWithCacheAndVerify = async <T>(
   cid: string,
   gateway = IPFS_GATEWAY,
+  maxBytes?: number,
 ): Promise<T> => {
   assertSafeUrl(gateway, 'IPFS gateway');
   try {
@@ -157,7 +259,7 @@ export const fetchIPFSWithCacheAndVerify = async <T>(
     return JSON.parse(data) as T;
   } catch {
     // Not in cache, fetch from IPFS
-    const { json } = await fetchIPFSDirectAndVerify<T>(cid, gateway);
+    const { json } = await fetchIPFSDirectAndVerify<T>(cid, gateway, maxBytes);
     await fs.writeFile(cacheFile, JSON.stringify(json), 'utf8');
     return json;
   }

--- a/utils/rate-limit.ts
+++ b/utils/rate-limit.ts
@@ -1,4 +1,5 @@
 import { sleep } from './sleep.js';
+import { parseEnvInt } from './env.js';
 
 const RATE_LIMIT_BATCH_SIZE = 120; // Max parallel requests per batch
 const RATE_LIMIT_DELAY_MS = 500; // Delay between batches
@@ -12,12 +13,6 @@ const RATE_LIMIT_DELAY_MS = 500; // Delay between batches
  * @param executor - Function to execute for each item
  * @returns Array of results
  */
-const parseEnvInt = (raw: string | undefined, fallback: number): number => {
-  if (!raw) return fallback;
-  const n = Number(raw);
-  return Number.isFinite(n) ? n : fallback;
-};
-
 export const executeBatchedWithRateLimit = async <T, R>(
   items: T[],
   executor: (item: T) => Promise<R>,


### PR DESCRIPTION


### Description

Content fetched from an IPFS gateway was buffered fully into memory with no size cap. A CID pointing at a large object could grow process memory until OOM (confirmed with a ~2.79GB file when the CLI is used as a library, e.g. by vaults-api).

- reject early when Content-Length exceeds the limit (cheap pre-check)
- stream the body and abort once accumulated bytes exceed the limit (Content-Length may be absent or lie)
- fail closed when the response has no readable body
- limit is configurable: maxBytes arg > IPFS_MAX_CONTENT_BYTES env >
  20 MiB default; threaded through fetchIPFS / fetchIPFSDirectAndVerify / fetchIPFSWithCacheAndVerify for library consumers
- public API and CID integrity verification unchanged
- extract shared parseEnvInt into utils/env.ts (dedup with rate-limit)
- tests: streaming abort, lying/absent Content-Length, exact boundary, multi-chunk reassembly, env/arg precedence, end-to-end maxBytes threading through both cache and no-cache paths

### Demo

<!-- If thee are visual changes add screenshots or record a [loom](https://www.loom.com/). -->

### Code review notes

<!-- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!-- List all possible edge cases and how to test them. -->

### Checklist:

- [ ]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

