### PR TITLE
fix: always submit consolidation fee exemption, align amount with CL spec

### DIFF
--- a/docs/cli/commands/consolidation.md
+++ b/docs/cli/commands/consolidation.md
@@ -136,7 +136,7 @@ The JSON file should contain a mapping of target pubkeys to arrays of source pub
 2. **Role Verification**: Checks that caller has `NODE_OPERATOR_FEE_EXEMPT_ROLE`
 3. **Report Freshness Check**: Validates that a fresh report has been submitted
 4. **Validator Info Retrieval**: Fetches current state of all source and target validators
-5. **Fee Calculation**: Calculates required rewards adjustment (fee exemption) based on consolidation
+5. **Fee Calculation**: Calculates required rewards adjustment (fee exemption) as the sum of `min(balance, effective_balance)` over the source validators — that is what the consensus layer moves to the target. Slashed sources are excluded (the consensus layer skips them, so their balance never reaches the vault); for a source that is not active the CLI asks whether its consolidation was already requested, since only then does its balance still arrive. The exemption is a per-batch delta and is always added; if a recent on-chain exemption with the same amount is found, the CLI shows its transaction hash and asks whether it already covered this batch (retry protection)
 6. **Inactive Validator Filtering**: Automatically removes any inactive validators from the consolidation list
 7. **Confirmation Display**: Shows detailed tables of source and target validators
 8. **Transaction Execution**:

--- a/docs/cli/get-started/consolidation.md
+++ b/docs/cli/get-started/consolidation.md
@@ -108,6 +108,10 @@ The CLI displays a table with all source and target validators before executing.
 - Check the fee exemption amount to be set
 - Confirm no unintended validators are included
 
+The fee exemption is a **per-batch delta** on the contract side (`addFeeExemption` increases `settledGrowth` by the given amount), so it is added for every consolidation batch. The node-operator fee is based on vault growth above `settledGrowth`, so without the exemption the consolidated balance stays in the fee base once the consolidation is processed and reported.
+
+The only reason to skip is a retry: if the exemption for this exact batch was already submitted in a previous run. The CLI detects this automatically — when a recent on-chain fee exemption with the same amount exists, it shows the transaction hash and asks whether that transaction covered this same batch. Otherwise the exemption is added without extra prompts.
+
 ### 5. Monitor on Beacon Chain
 
 After submission, consolidation is processed at the consensus layer. Track progress via a Beacon Chain explorer or:

--- a/features/consolidation.ts
+++ b/features/consolidation.ts
@@ -25,6 +25,12 @@ import {
   getSourceAndTargetPubkeysFromEncodedCall,
   addDummyTargetAndSourceValidator,
   logCancel,
+  findRecentFeeExemptions,
+  formatFeeExemptionMatch,
+  consolidatedBalance,
+  FEE_EXEMPTION_DUPLICATE_LOOKBACK_SEC,
+  FeeExemptionMatch,
+  logError,
 } from 'utils';
 import { DashboardAbi } from 'abi';
 import { TargetAndSourceValidators } from 'utils/consolidation/types.js';
@@ -253,10 +259,13 @@ export const consolidateAndIncreaseFeeExemptionWithoutBatching = async ({
           feePerRequest: feePerRequest,
         });
 
-        currentFeeExemption +=
-          targetAndSourceValidators
-            .get(targetPubkey)
-            ?.sourceValidators.get(sourcePubkey)?.balance ?? 0n;
+        const consolidatedSource = targetAndSourceValidators
+          .get(targetPubkey)
+          ?.sourceValidators.get(sourcePubkey);
+        // same basis as calculateAndConfirmFeeExemption, or the remainder below goes negative
+        currentFeeExemption += consolidatedSource
+          ? consolidatedBalance(consolidatedSource)
+          : 0n;
 
         consolidatedSourcePubkeys.push(sourcePubkey);
       }
@@ -298,46 +307,77 @@ export const consolidateAndIncreaseFeeExemptionWithoutBatching = async ({
   }
 };
 
-export const confirmNewFeeExemption = async (
+// addFeeExemption is a delta (settledGrowth += amount), so every batch needs one;
+// skip is offered only on on-chain evidence that this batch's exemption already landed
+export const confirmFeeExemptionIncrease = async (
   dashboardContract: DashboardContract,
   newFeeExemption: bigint,
-) => {
-  const settledGrowth = await callReadMethodSilent({
+): Promise<{ shouldAddFeeExemption: boolean }> => {
+  if (newFeeExemption === 0n) {
+    return { shouldAddFeeExemption: false };
+  }
+
+  const latestCorrectionTimestamp = await callReadMethodSilent({
     contract: dashboardContract,
-    methodName: 'settledGrowth',
+    methodName: 'latestCorrectionTimestamp',
     payload: [],
   });
 
-  if (settledGrowth < newFeeExemption) {
-    return {
-      isNeedToIncreaseFeeExemption: true,
-      settledGrowth: settledGrowth,
-    };
+  const lookbackStart =
+    BigInt(Math.floor(Date.now() / 1000)) -
+    FEE_EXEMPTION_DUPLICATE_LOOKBACK_SEC;
+
+  // no recent correction — nothing to duplicate
+  if (latestCorrectionTimestamp < lookbackStart) {
+    return { shouldAddFeeExemption: true };
   }
 
-  const confirmNewFeeExemption = await confirmOperation(
-    `Do you want to increase the fee exemption to ${formatEther(newFeeExemption)} ETH?
-    Current settled growth: ${formatEther(settledGrowth)} ETH`,
+  const hideSpinner = showSpinner();
+  let matches: FeeExemptionMatch[] | null = null;
+  try {
+    matches = await findRecentFeeExemptions(
+      dashboardContract.address,
+      newFeeExemption,
+    );
+  } catch (error) {
+    // logError, not printError — printError rethrows and would abort the flow
+    logError('Could not scan recent fee exemptions.');
+    if (error instanceof Error && error.message) logError(error.message);
+  } finally {
+    hideSpinner();
+  }
+
+  if (matches?.length === 0) {
+    return { shouldAddFeeExemption: true };
+  }
+
+  // advisory only: the same RPC could have fabricated it (threat-model A3)
+  const evidence = matches
+    ? `A fee exemption matching this batch amount was already added recently (verify against a block explorer):
+    ${matches.map(formatFeeExemptionMatch).join('\n    ')}`
+    : `Could not scan recent on-chain fee exemptions (RPC error), but a manual settled growth correction happened recently on this vault.`;
+
+  // must stay the first prompt — auto-confirm (--yes / test env) then means "add", not "skip"
+  const addAnyway = await confirmOperation(
+    `${evidence}
+    Node-operator fee is based on vault growth above settled growth, and this call raises settled growth by the exempted amount.
+    If the exemption for THIS SAME consolidation batch was already added, adding it again would raise settled growth twice.
+    If it was not, the consolidated balance stays in the fee base once the consolidation is processed and reported.
+    Add fee exemption of ${formatEther(newFeeExemption)} ETH now?`,
   );
 
-  if (!confirmNewFeeExemption) {
-    const confirmUseSettledGrowth = await confirmOperation(
-      `Do you want to skip increasing fee exemption and use current settled growth?
-      Current settled growth: ${formatEther(settledGrowth)} ETH`,
-    );
-    if (!confirmUseSettledGrowth) {
-      logCancel('The user has canceled the use of settled growth');
-      throw new Error('User cancelled consolidation');
-    }
-
-    return {
-      isNeedToIncreaseFeeExemption: false,
-      settledGrowth: settledGrowth,
-    };
+  if (addAnyway) {
+    return { shouldAddFeeExemption: true };
   }
 
-  return {
-    isNeedToIncreaseFeeExemption: true,
-    settledGrowth: settledGrowth,
-  };
+  const confirmSkip = await confirmOperation(
+    `Skip adding the fee exemption?
+    Unless the exemption for this exact batch was already added, ${formatEther(newFeeExemption)} ETH stays in the node-operator fee base once the consolidation is processed and reported.`,
+  );
+  if (!confirmSkip) {
+    logCancel('The user has canceled the fee exemption decision');
+    throw new Error('User cancelled consolidation');
+  }
+
+  return { shouldAddFeeExemption: false };
 };

--- a/programs/use-cases/consolidation/write.ts
+++ b/programs/use-cases/consolidation/write.ts
@@ -23,7 +23,7 @@ import { consolidation } from './main.js';
 import {
   consolidateAndIncreaseFeeExemptionWithoutBatching,
   consolidationRequestsAndIncreaseFeeExemption,
-  confirmNewFeeExemption,
+  confirmFeeExemptionIncrease,
 } from 'features/consolidation.js';
 import { checkVaultRole, checkIsReportFresh } from 'features';
 import { getAccount } from 'providers';
@@ -127,7 +127,7 @@ consolidationWrite
       const feeExemption = await calculateAndConfirmFeeExemption(
         targetAndSourceValidators,
       );
-      const { isNeedToIncreaseFeeExemption } = await confirmNewFeeExemption(
+      const { shouldAddFeeExemption } = await confirmFeeExemptionIncrease(
         dashboardContract,
         feeExemption,
       );
@@ -144,7 +144,7 @@ consolidationWrite
         const populatedTxs = await consolidationRequestsAndIncreaseFeeExemption(
           {
             targetAndSourceValidators,
-            feeExemption: isNeedToIncreaseFeeExemption ? feeExemption : 0n,
+            feeExemption: shouldAddFeeExemption ? feeExemption : 0n,
             dashboard,
           },
         );
@@ -168,7 +168,7 @@ consolidationWrite
       } else {
         await consolidateAndIncreaseFeeExemptionWithoutBatching({
           targetAndSourceValidators,
-          feeExemption: isNeedToIncreaseFeeExemption ? feeExemption : 0n,
+          feeExemption: shouldAddFeeExemption ? feeExemption : 0n,
           dashboard,
         });
       }

--- a/tests/fixtures/consolidation-fixtures.ts
+++ b/tests/fixtures/consolidation-fixtures.ts
@@ -28,6 +28,7 @@ export const createValidatorInfo = (
   balance: 32000000000n,
   index: '1',
   effectiveBalance: 32000000000n,
+  slashed: false,
   ...overrides,
 });
 

--- a/tests/utils/consolidation-fee-exemption-calc.test.ts
+++ b/tests/utils/consolidation-fee-exemption-calc.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { consolidatedBalance } from '../../utils/consolidation/validator-info.js';
+import {
+  VALID_PUBKEY_1,
+  VALID_PUBKEY_2,
+  VALID_PUBKEY_3,
+  createValidatorInfo,
+  createTargetAndSourceMap,
+} from '../fixtures/consolidation-fixtures.js';
+
+const mockConfirmOperation = vi.fn();
+
+vi.mock('utils', async () => {
+  const logging = await vi.importActual<
+    typeof import('utils/logging/console.js')
+  >('../../utils/logging/console.js');
+
+  return {
+    ...logging,
+    confirmOperation: mockConfirmOperation,
+  };
+});
+
+const importSubject = async () => {
+  const { calculateAndConfirmFeeExemption } =
+    await import('../../utils/consolidation/confirms.js');
+  return calculateAndConfirmFeeExemption;
+};
+
+const ETH = 1_000_000_000_000_000_000n;
+
+describe('consolidatedBalance', () => {
+  it('returns the effective balance when it is below the actual balance', () => {
+    const info = createValidatorInfo({
+      balance: 32n * ETH + ETH / 2n,
+      effectiveBalance: 32n * ETH,
+    });
+
+    expect(consolidatedBalance(info)).toBe(32n * ETH);
+  });
+
+  it('returns the actual balance when it dropped below the effective balance', () => {
+    const info = createValidatorInfo({
+      balance: 31n * ETH,
+      effectiveBalance: 32n * ETH,
+    });
+
+    expect(consolidatedBalance(info)).toBe(31n * ETH);
+  });
+
+  it('returns zero for a slashed validator', () => {
+    const info = createValidatorInfo({
+      balance: 32n * ETH,
+      effectiveBalance: 32n * ETH,
+      slashed: true,
+    });
+
+    expect(consolidatedBalance(info)).toBe(0n);
+  });
+});
+
+describe('calculateAndConfirmFeeExemption', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfirmOperation.mockResolvedValue(true);
+  });
+
+  it('sums active sources without asking about them', async () => {
+    const calculateAndConfirmFeeExemption = await importSubject();
+    const map = createTargetAndSourceMap([
+      {
+        target: VALID_PUBKEY_1,
+        sources: [
+          {
+            pubkey: VALID_PUBKEY_2,
+            info: { balance: 33n * ETH, effectiveBalance: 32n * ETH },
+          },
+          {
+            pubkey: VALID_PUBKEY_3,
+            info: { balance: 33n * ETH, effectiveBalance: 32n * ETH },
+          },
+        ],
+      },
+    ]);
+
+    const feeExemption = await calculateAndConfirmFeeExemption(map);
+
+    // effective balance (32) is what moves, not the 33 ETH actual balance
+    expect(feeExemption).toBe(64n * ETH);
+    // only the final "Fee Exemption: … Continue?" confirmation
+    expect(mockConfirmOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it('excludes a slashed source without asking', async () => {
+    const calculateAndConfirmFeeExemption = await importSubject();
+    const map = createTargetAndSourceMap([
+      {
+        target: VALID_PUBKEY_1,
+        sources: [
+          {
+            pubkey: VALID_PUBKEY_2,
+            info: {
+              status: 'active_slashed',
+              slashed: true,
+              balance: 32n * ETH,
+              effectiveBalance: 32n * ETH,
+            },
+          },
+        ],
+      },
+    ]);
+
+    const feeExemption = await calculateAndConfirmFeeExemption(map);
+
+    expect(feeExemption).toBe(0n);
+    expect(mockConfirmOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks about a non-active source and counts it when confirmed', async () => {
+    const calculateAndConfirmFeeExemption = await importSubject();
+    const map = createTargetAndSourceMap([
+      {
+        target: VALID_PUBKEY_1,
+        sources: [
+          {
+            pubkey: VALID_PUBKEY_2,
+            info: {
+              status: 'active_exiting',
+              balance: 32n * ETH,
+              effectiveBalance: 32n * ETH,
+            },
+          },
+        ],
+      },
+    ]);
+
+    const feeExemption = await calculateAndConfirmFeeExemption(map);
+
+    expect(feeExemption).toBe(32n * ETH);
+    expect(mockConfirmOperation).toHaveBeenCalledTimes(2);
+    expect(mockConfirmOperation.mock.calls[0]?.[0]).toContain('active_exiting');
+  });
+
+  it('skips a non-active source when the operator declines', async () => {
+    const calculateAndConfirmFeeExemption = await importSubject();
+    mockConfirmOperation
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const map = createTargetAndSourceMap([
+      {
+        target: VALID_PUBKEY_1,
+        sources: [
+          {
+            pubkey: VALID_PUBKEY_2,
+            info: {
+              status: 'active_exiting',
+              balance: 32n * ETH,
+              effectiveBalance: 32n * ETH,
+            },
+          },
+        ],
+      },
+    ]);
+
+    const feeExemption = await calculateAndConfirmFeeExemption(map);
+
+    expect(feeExemption).toBe(0n);
+  });
+
+  it('throws when the operator rejects the calculated amount', async () => {
+    const calculateAndConfirmFeeExemption = await importSubject();
+    mockConfirmOperation.mockResolvedValue(false);
+    const map = createTargetAndSourceMap([
+      { target: VALID_PUBKEY_1, sources: [{ pubkey: VALID_PUBKEY_2 }] },
+    ]);
+
+    await expect(calculateAndConfirmFeeExemption(map)).rejects.toThrow(
+      'User cancelled consolidation',
+    );
+  });
+});

--- a/tests/utils/consolidation-fee-exemption-confirm.test.ts
+++ b/tests/utils/consolidation-fee-exemption-confirm.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockConfirmOperation = vi.fn();
+const mockCallReadMethodSilent = vi.fn();
+const mockFindRecentFeeExemptions = vi.fn();
+const mockLogCancel = vi.fn();
+
+const DAY_SEC = 24n * 60n * 60n;
+const HOUR_SEC = 60n * 60n;
+const NOW_SEC = BigInt(Math.floor(Date.now() / 1000));
+
+// real loggers: a stubbed printError would hide that it rethrows
+vi.mock('utils', async () => {
+  const logging = await vi.importActual<
+    typeof import('utils/logging/console.js')
+  >('../../utils/logging/console.js');
+  const errorHandler = await vi.importActual<
+    typeof import('utils/error-handler.js')
+  >('../../utils/error-handler.js');
+
+  return {
+    ...logging,
+    ...errorHandler,
+    callReadMethodSilent: mockCallReadMethodSilent,
+    confirmOperation: mockConfirmOperation,
+    findRecentFeeExemptions: mockFindRecentFeeExemptions,
+    formatFeeExemptionMatch: () => 'formatted-match',
+    FEE_EXEMPTION_DUPLICATE_LOOKBACK_SEC: DAY_SEC,
+    logCancel: mockLogCancel,
+    showSpinner: () => () => {},
+    callWriteMethodWithReceipt: vi.fn(),
+    callWriteMethodWithReceiptBatchCalls: vi.fn(),
+    flattenSourcePubkeys: vi.fn(),
+    getSourceAndTargetPubkeysFromEncodedCall: vi.fn(),
+    addDummyTargetAndSourceValidator: vi.fn(),
+  };
+});
+
+vi.mock('providers', () => ({ getPublicClient: vi.fn() }));
+vi.mock('contracts', () => ({
+  getDashboardContract: vi.fn(),
+  getValidatorConsolidationRequestsContract: vi.fn(),
+}));
+vi.mock('abi', () => ({ DashboardAbi: [] }));
+
+const DASHBOARD_CONTRACT = {
+  address: '0x1234567890abcdef1234567890abcdef12345678',
+} as any;
+
+const FEE_EXEMPTION = 32_000_000_000_000_000_000n;
+
+const importSubject = async () => {
+  const { confirmFeeExemptionIncrease } =
+    await import('../../features/consolidation.js');
+  return confirmFeeExemptionIncrease;
+};
+
+const aMatch = {
+  txHash: `0x${'ab'.repeat(32)}`,
+  blockNumber: 1n,
+  delta: FEE_EXEMPTION,
+  timestamp: NOW_SEC,
+};
+
+describe('confirmFeeExemptionIncrease', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does nothing when there is no exemption to add', async () => {
+    const confirmFeeExemptionIncrease = await importSubject();
+
+    const result = await confirmFeeExemptionIncrease(DASHBOARD_CONTRACT, 0n);
+
+    expect(result).toEqual({ shouldAddFeeExemption: false });
+    expect(mockCallReadMethodSilent).not.toHaveBeenCalled();
+    expect(mockConfirmOperation).not.toHaveBeenCalled();
+  });
+
+  it('adds the exemption without prompting when there are no recent corrections', async () => {
+    mockCallReadMethodSilent.mockResolvedValue(0n);
+    const confirmFeeExemptionIncrease = await importSubject();
+
+    const result = await confirmFeeExemptionIncrease(
+      DASHBOARD_CONTRACT,
+      FEE_EXEMPTION,
+    );
+
+    expect(result).toEqual({ shouldAddFeeExemption: true });
+    expect(mockFindRecentFeeExemptions).not.toHaveBeenCalled();
+    expect(mockConfirmOperation).not.toHaveBeenCalled();
+  });
+
+  it('adds the exemption without prompting when no matching exemption is found', async () => {
+    mockCallReadMethodSilent.mockResolvedValue(NOW_SEC - HOUR_SEC);
+    mockFindRecentFeeExemptions.mockResolvedValue([]);
+    const confirmFeeExemptionIncrease = await importSubject();
+
+    const result = await confirmFeeExemptionIncrease(
+      DASHBOARD_CONTRACT,
+      FEE_EXEMPTION,
+    );
+
+    expect(result).toEqual({ shouldAddFeeExemption: true });
+    expect(mockFindRecentFeeExemptions).toHaveBeenCalledWith(
+      DASHBOARD_CONTRACT.address,
+      FEE_EXEMPTION,
+    );
+    expect(mockConfirmOperation).not.toHaveBeenCalled();
+  });
+
+  // --yes / NODE_ENV=test auto-confirm every prompt, so the first one must mean "add"
+  it('adds the exemption when prompts are auto-confirmed', async () => {
+    mockCallReadMethodSilent.mockResolvedValue(NOW_SEC - HOUR_SEC);
+    mockFindRecentFeeExemptions.mockResolvedValue([aMatch]);
+    mockConfirmOperation.mockResolvedValue(true);
+    const confirmFeeExemptionIncrease = await importSubject();
+
+    const result = await confirmFeeExemptionIncrease(
+      DASHBOARD_CONTRACT,
+      FEE_EXEMPTION,
+    );
+
+    expect(result).toEqual({ shouldAddFeeExemption: true });
+    expect(mockConfirmOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips only after an explicit decline and an explicit skip confirmation', async () => {
+    mockCallReadMethodSilent.mockResolvedValue(NOW_SEC - HOUR_SEC);
+    mockFindRecentFeeExemptions.mockResolvedValue([aMatch]);
+    mockConfirmOperation
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const confirmFeeExemptionIncrease = await importSubject();
+
+    const result = await confirmFeeExemptionIncrease(
+      DASHBOARD_CONTRACT,
+      FEE_EXEMPTION,
+    );
+
+    expect(result).toEqual({ shouldAddFeeExemption: false });
+    expect(mockConfirmOperation).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels consolidation when the operator declines both prompts', async () => {
+    mockCallReadMethodSilent.mockResolvedValue(NOW_SEC - HOUR_SEC);
+    mockFindRecentFeeExemptions.mockResolvedValue([aMatch]);
+    mockConfirmOperation.mockResolvedValue(false);
+    const confirmFeeExemptionIncrease = await importSubject();
+
+    await expect(
+      confirmFeeExemptionIncrease(DASHBOARD_CONTRACT, FEE_EXEMPTION),
+    ).rejects.toThrow('User cancelled consolidation');
+    expect(mockLogCancel).toHaveBeenCalled();
+  });
+
+  // fails if fail-soft regresses into a hard abort
+  it('falls back to an operator decision when the log scan fails', async () => {
+    mockCallReadMethodSilent.mockResolvedValue(NOW_SEC - HOUR_SEC);
+    mockFindRecentFeeExemptions.mockRejectedValue(new Error('range too wide'));
+    mockConfirmOperation.mockResolvedValue(true);
+    const confirmFeeExemptionIncrease = await importSubject();
+
+    const result = await confirmFeeExemptionIncrease(
+      DASHBOARD_CONTRACT,
+      FEE_EXEMPTION,
+    );
+
+    expect(result).toEqual({ shouldAddFeeExemption: true });
+    expect(mockConfirmOperation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/utils/consolidation-fee-exemption.test.ts
+++ b/tests/utils/consolidation-fee-exemption.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hex } from 'viem';
+
+import {
+  matchFeeExemptionLogs,
+  findRecentFeeExemptions,
+  formatFeeExemptionMatch,
+  SettledGrowthSetLog,
+} from '../../utils/consolidation/fee-exemption.js';
+
+const mockGetBlockNumber = vi.fn();
+const mockGetContractEvents = vi.fn();
+const mockGetBlock = vi.fn();
+
+vi.mock('providers', () => ({
+  getPublicClient: async () => ({
+    getBlockNumber: mockGetBlockNumber,
+    getContractEvents: mockGetContractEvents,
+    getBlock: mockGetBlock,
+  }),
+}));
+
+const TX_EXEMPTION = '0xaaa1' as Hex;
+const TX_DISBURSE = '0xbbb2' as Hex;
+const TX_OTHER = '0xccc3' as Hex;
+const DASHBOARD = '0x1234567890abcdef1234567890abcdef12345678';
+
+const settledGrowthLog = (
+  transactionHash: Hex,
+  oldSettledGrowth: bigint,
+  newSettledGrowth: bigint,
+  blockNumber = 100n,
+): SettledGrowthSetLog => ({
+  transactionHash,
+  blockNumber,
+  args: { oldSettledGrowth, newSettledGrowth },
+});
+
+describe('matchFeeExemptionLogs', () => {
+  it('matches a correction tx with delta equal to the amount', () => {
+    const logs = [settledGrowthLog(TX_EXEMPTION, 100n, 132n)];
+    const matches = matchFeeExemptionLogs(logs, new Set([TX_EXEMPTION]), 32n);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({ txHash: TX_EXEMPTION, delta: 32n });
+  });
+
+  it('ignores SettledGrowthSet from disburseFee (no correction event in tx)', () => {
+    const logs = [settledGrowthLog(TX_DISBURSE, 100n, 132n)];
+    const matches = matchFeeExemptionLogs(logs, new Set(), 32n);
+
+    expect(matches).toHaveLength(0);
+  });
+
+  it('ignores corrections with a different delta', () => {
+    const logs = [
+      settledGrowthLog(TX_EXEMPTION, 100n, 132n),
+      settledGrowthLog(TX_OTHER, 132n, 196n),
+    ];
+    const matches = matchFeeExemptionLogs(
+      logs,
+      new Set([TX_EXEMPTION, TX_OTHER]),
+      64n,
+    );
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.txHash).toBe(TX_OTHER);
+  });
+
+  it('ignores downward corrections (negative delta)', () => {
+    const logs = [settledGrowthLog(TX_OTHER, 132n, 100n)];
+    const matches = matchFeeExemptionLogs(logs, new Set([TX_OTHER]), 32n);
+
+    expect(matches).toHaveLength(0);
+  });
+
+  it('returns all matching corrections', () => {
+    const logs = [
+      settledGrowthLog(TX_EXEMPTION, 100n, 132n, 100n),
+      settledGrowthLog(TX_OTHER, 132n, 164n, 200n),
+    ];
+    const matches = matchFeeExemptionLogs(
+      logs,
+      new Set([TX_EXEMPTION, TX_OTHER]),
+      32n,
+    );
+
+    expect(matches).toHaveLength(2);
+  });
+});
+
+describe('formatFeeExemptionMatch', () => {
+  const VALID_HASH = `0x${'ab'.repeat(32)}` as Hex;
+
+  it('renders a valid hash and timestamp', () => {
+    const line = formatFeeExemptionMatch({
+      txHash: VALID_HASH,
+      blockNumber: 100n,
+      delta: 32_000_000_000_000_000_000n,
+      timestamp: 1_700_000_000n,
+    });
+
+    expect(line).toBe(`32 ETH in tx ${VALID_HASH} at 2023-11-14T22:13:20.000Z`);
+  });
+
+  it('replaces a tx hash carrying terminal escape sequences', () => {
+    const line = formatFeeExemptionMatch({
+      txHash: '[2K[1ASkip the exemption' as Hex,
+      blockNumber: 100n,
+      delta: 32_000_000_000_000_000_000n,
+      timestamp: 1_700_000_000n,
+    });
+
+    expect(line).toContain('<invalid tx hash from RPC>');
+    expect(line).not.toContain('');
+  });
+
+  it('replaces a non-hex tx hash of the right length', () => {
+    const line = formatFeeExemptionMatch({
+      txHash: `0x${'zz'.repeat(32)}` as Hex,
+      blockNumber: 100n,
+      delta: 1n,
+      timestamp: 1_700_000_000n,
+    });
+
+    expect(line).toContain('<invalid tx hash from RPC>');
+  });
+
+  it('replaces an out-of-range timestamp instead of throwing', () => {
+    const line = formatFeeExemptionMatch({
+      txHash: VALID_HASH,
+      blockNumber: 100n,
+      delta: 1n,
+      timestamp: 2n ** 64n,
+    });
+
+    expect(line).toContain('<invalid timestamp from RPC>');
+  });
+});
+
+describe('findRecentFeeExemptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // mimics an RPC honouring fromBlock/toBlock, so chunked scans see each log once
+  const mockChainLogs = (
+    settledGrowthLogs: SettledGrowthSetLog[],
+    correctionTxHashes: Hex[],
+  ) => {
+    mockGetContractEvents.mockImplementation(
+      async ({ eventName, fromBlock, toBlock }) => {
+        const inRange = settledGrowthLogs.filter(
+          (log) => log.blockNumber >= fromBlock && log.blockNumber <= toBlock,
+        );
+        if (eventName === 'SettledGrowthSet') return inRange;
+
+        return inRange
+          .filter((log) => correctionTxHashes.includes(log.transactionHash))
+          .map((log) => ({ transactionHash: log.transactionHash }));
+      },
+    );
+  };
+
+  it('returns matching exemptions with block timestamps', async () => {
+    mockGetBlockNumber.mockResolvedValue(1_000_000n);
+    mockChainLogs(
+      [
+        settledGrowthLog(TX_EXEMPTION, 100n, 132n, 999_000n),
+        settledGrowthLog(TX_DISBURSE, 132n, 150n, 999_500n),
+      ],
+      [TX_EXEMPTION],
+    );
+    mockGetBlock.mockResolvedValue({ timestamp: 1_700_000_000n });
+
+    const matches = await findRecentFeeExemptions(DASHBOARD, 32n);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      txHash: TX_EXEMPTION,
+      delta: 32n,
+      timestamp: 1_700_000_000n,
+    });
+  });
+
+  it('queries both events over the same block range', async () => {
+    mockGetBlockNumber.mockResolvedValue(1_000_000n);
+    mockGetContractEvents.mockResolvedValue([]);
+
+    // 1200 sec / 12 sec per block = 100 blocks back, fits in a single chunk
+    await findRecentFeeExemptions(DASHBOARD, 32n, 1200n);
+
+    const ranges = mockGetContractEvents.mock.calls.map(
+      ([{ fromBlock, toBlock }]) => [fromBlock, toBlock],
+    );
+    expect(ranges).toEqual([
+      [999_900n, 1_000_000n],
+      [999_900n, 1_000_000n],
+    ]);
+  });
+
+  it('splits a wide lookback into chunks without rescanning blocks', async () => {
+    mockGetBlockNumber.mockResolvedValue(100_000n);
+    mockGetContractEvents.mockResolvedValue([]);
+
+    // 25 000 blocks back over a 10 000-block chunk size = 3 chunks per event
+    await findRecentFeeExemptions(DASHBOARD, 32n, 25_000n * 12n);
+
+    const settledGrowthRanges = mockGetContractEvents.mock.calls
+      .filter(([{ eventName }]) => eventName === 'SettledGrowthSet')
+      .map(([{ fromBlock, toBlock }]) => [fromBlock, toBlock]);
+    expect(settledGrowthRanges).toEqual([
+      [75_000n, 84_999n],
+      [85_000n, 94_999n],
+      [95_000n, 100_000n],
+    ]);
+  });
+
+  it('clamps fromBlock to 0 when the chain is shorter than the lookback', async () => {
+    mockGetBlockNumber.mockResolvedValue(10n);
+    mockGetContractEvents.mockResolvedValue([]);
+
+    await findRecentFeeExemptions(DASHBOARD, 32n);
+
+    const firstCall = mockGetContractEvents.mock.calls[0];
+    expect(firstCall?.[0]?.fromBlock).toBe(0n);
+    expect(firstCall?.[0]?.toBlock).toBe(10n);
+  });
+
+  it('returns empty when only disburse events exist', async () => {
+    mockGetBlockNumber.mockResolvedValue(1_000_000n);
+    mockChainLogs([settledGrowthLog(TX_DISBURSE, 100n, 132n, 999_000n)], []);
+
+    const matches = await findRecentFeeExemptions(DASHBOARD, 32n);
+
+    expect(matches).toHaveLength(0);
+    expect(mockGetBlock).not.toHaveBeenCalled();
+  });
+});

--- a/utils/consolidation/confirms.ts
+++ b/utils/consolidation/confirms.ts
@@ -1,7 +1,8 @@
 import { Address, formatEther } from 'viem';
-import { logCancel, confirmOperation } from 'utils';
+import { logCancel, logError, confirmOperation } from 'utils';
 
 import { TargetAndSourceValidators } from './types.js';
+import { consolidatedBalance } from './validator-info.js';
 
 export const confirmToConsolidate = async (
   targetAndSourceValidators: TargetAndSourceValidators,
@@ -30,17 +31,32 @@ export const calculateAndConfirmFeeExemption = async (
 ): Promise<bigint> => {
   let feeExemption = 0n;
 
-  for (const [, { sourceValidators }] of targetAndSourceValidators) {
+  for (const [target, { sourceValidators }] of targetAndSourceValidators) {
     for (const [source, sourceValidatorInfo] of sourceValidators) {
       if (sourceValidatorInfo.status === 'active_ongoing') {
-        feeExemption += sourceValidatorInfo.effectiveBalance;
-      } else {
-        const confirm = await confirmOperation(
-          `Validator with this pubkey ${source} is not in active state. Should we consider its balance for fee exemption?`,
+        feeExemption += consolidatedBalance(sourceValidatorInfo);
+        continue;
+      }
+
+      // a slashed source is skipped by the consensus layer, so nothing reaches the vault
+      if (sourceValidatorInfo.slashed) {
+        logError(
+          `Validator ${source} is slashed: its balance will not reach the vault, so it is not exempted.`,
         );
-        if (confirm) {
-          feeExemption += sourceValidatorInfo.effectiveBalance;
-        }
+        continue;
+      }
+
+      // an exit epoch is set both by an accepted consolidation request and by a
+      // voluntary/triggered exit, and the two need opposite answers here — only the
+      // operator knows which one applies, so ask instead of guessing
+      const confirm = await confirmOperation(
+        `Validator ${source} is not active (status: ${sourceValidatorInfo.status}), balance ${formatEther(sourceValidatorInfo.balance)} ETH.
+    Answer yes only if its consolidation into ${target} was already requested — then that balance still reaches the vault and needs the exemption.
+    Answer no if it is exiting for any other reason — then the balance goes to its own withdrawal credentials and must not be exempted.
+    Count this validator towards the fee exemption?`,
+      );
+      if (confirm) {
+        feeExemption += consolidatedBalance(sourceValidatorInfo);
       }
     }
   }

--- a/utils/consolidation/fee-exemption.ts
+++ b/utils/consolidation/fee-exemption.ts
@@ -1,0 +1,121 @@
+import { Address, formatEther, Hex } from 'viem';
+
+import { getPublicClient } from 'providers';
+import { DashboardAbi } from 'abi';
+
+import { bigIntMax, bigIntMin } from '../big-int.js';
+
+const AVG_BLOCK_TIME_SEC = 12n;
+
+// providers commonly cap eth_getLogs at 10k blocks
+const MAX_LOG_RANGE_BLOCKS = 10_000n;
+
+// retries happen within hours; a wider window matches the previous batch's
+// exemption instead, since batch amounts are round and repeat
+export const FEE_EXEMPTION_DUPLICATE_LOOKBACK_SEC = 24n * 60n * 60n; // 24 hours
+
+export type SettledGrowthSetLog = {
+  transactionHash: Hex;
+  blockNumber: bigint;
+  args: { oldSettledGrowth: bigint; newSettledGrowth: bigint };
+};
+
+export type FeeExemptionMatch = {
+  txHash: Hex;
+  blockNumber: bigint;
+  delta: bigint;
+  timestamp: bigint;
+};
+
+// disburseFee also emits SettledGrowthSet; only corrections emit CorrectionTimestampUpdated
+export const matchFeeExemptionLogs = (
+  settledGrowthLogs: SettledGrowthSetLog[],
+  correctionTxHashes: Set<Hex>,
+  amount: bigint,
+): Omit<FeeExemptionMatch, 'timestamp'>[] =>
+  settledGrowthLogs
+    .filter((log) => correctionTxHashes.has(log.transactionHash))
+    .map((log) => ({
+      txHash: log.transactionHash,
+      blockNumber: log.blockNumber,
+      delta: log.args.newSettledGrowth - log.args.oldSettledGrowth,
+    }))
+    .filter((match) => match.delta === amount);
+
+// viem does not validate log envelope fields at runtime
+export const formatFeeExemptionMatch = (match: FeeExemptionMatch): string => {
+  const txHash = /^0x[0-9a-fA-F]{64}$/.test(match.txHash)
+    ? match.txHash
+    : '<invalid tx hash from RPC>';
+  const timestampMs = Number(match.timestamp) * 1000;
+  const at = Number.isSafeInteger(timestampMs)
+    ? new Date(timestampMs).toISOString()
+    : '<invalid timestamp from RPC>';
+
+  return `${formatEther(match.delta)} ETH in tx ${txHash} at ${at}`;
+};
+
+export const findRecentFeeExemptions = async (
+  dashboard: Address,
+  amount: bigint,
+  lookbackSec: bigint = FEE_EXEMPTION_DUPLICATE_LOOKBACK_SEC,
+): Promise<FeeExemptionMatch[]> => {
+  const publicClient = await getPublicClient();
+  const currentBlock = await publicClient.getBlockNumber();
+  const lookbackBlocks = lookbackSec / AVG_BLOCK_TIME_SEC;
+  const fromBlock = bigIntMax(currentBlock - lookbackBlocks, 0n);
+
+  const settledGrowthLogs = [];
+  const correctionLogs = [];
+
+  for (
+    let chunkStart = fromBlock;
+    chunkStart <= currentBlock;
+    chunkStart += MAX_LOG_RANGE_BLOCKS
+  ) {
+    const toBlock = bigIntMin(
+      chunkStart + MAX_LOG_RANGE_BLOCKS - 1n,
+      currentBlock,
+    );
+
+    const [chunkSettledGrowthLogs, chunkCorrectionLogs] = await Promise.all([
+      publicClient.getContractEvents({
+        address: dashboard,
+        abi: DashboardAbi,
+        eventName: 'SettledGrowthSet',
+        fromBlock: chunkStart,
+        toBlock,
+        strict: true,
+      }),
+      publicClient.getContractEvents({
+        address: dashboard,
+        abi: DashboardAbi,
+        eventName: 'CorrectionTimestampUpdated',
+        fromBlock: chunkStart,
+        toBlock,
+        strict: true,
+      }),
+    ]);
+
+    settledGrowthLogs.push(...chunkSettledGrowthLogs);
+    correctionLogs.push(...chunkCorrectionLogs);
+  }
+
+  const correctionTxHashes = new Set(
+    correctionLogs.map((log) => log.transactionHash),
+  );
+  const matches = matchFeeExemptionLogs(
+    settledGrowthLogs,
+    correctionTxHashes,
+    amount,
+  );
+
+  return Promise.all(
+    matches.map(async (match) => {
+      const block = await publicClient.getBlock({
+        blockNumber: match.blockNumber,
+      });
+      return { ...match, timestamp: block.timestamp };
+    }),
+  );
+};

--- a/utils/consolidation/index.ts
+++ b/utils/consolidation/index.ts
@@ -3,4 +3,5 @@ export * from './validators-checks.js';
 export * from './validator-info.js';
 export * from './logs.js';
 export * from './confirms.js';
+export * from './fee-exemption.js';
 export * from './pubkeys.js';

--- a/utils/consolidation/pubkeys.ts
+++ b/utils/consolidation/pubkeys.ts
@@ -46,6 +46,7 @@ export const addDummyTargetAndSourceValidator = (
         balance: feeExemption,
         index: '0',
         effectiveBalance: feeExemption,
+        slashed: false,
       },
       sourceValidators: new Map([
         [
@@ -55,6 +56,7 @@ export const addDummyTargetAndSourceValidator = (
             balance: feeExemption,
             index: '0',
             effectiveBalance: feeExemption,
+            slashed: false,
           },
         ],
       ]),

--- a/utils/consolidation/types.ts
+++ b/utils/consolidation/types.ts
@@ -5,6 +5,7 @@ export type ValidatorInfo = {
   balance: bigint;
   index: string;
   effectiveBalance: bigint;
+  slashed: boolean;
 };
 
 export type PubkeyMap = Record<Hex, Hex[]>;

--- a/utils/consolidation/validator-info.ts
+++ b/utils/consolidation/validator-info.ts
@@ -1,8 +1,14 @@
 import { Hex, parseGwei } from 'viem';
 
 import { ValidatorsInfo } from '../fetch-cl.js';
+import { bigIntMin } from '../big-int.js';
 
-import { TargetAndSourceValidators } from './types.js';
+import { TargetAndSourceValidators, ValidatorInfo } from './types.js';
+
+// what process_pending_consolidations moves to the target:
+// min(balance, effective_balance), and nothing at all for a slashed source
+export const consolidatedBalance = (info: ValidatorInfo): bigint =>
+  info.slashed ? 0n : bigIntMin(info.balance, info.effectiveBalance);
 
 export const getTargetAndSourceValidatorsInfo = (
   targetPubkeys: Hex[],
@@ -26,6 +32,7 @@ export const getTargetAndSourceValidatorsInfo = (
         effectiveBalance: parseGwei(
           targetValidatorInfo.validator.effective_balance,
         ),
+        slashed: targetValidatorInfo.validator.slashed,
       },
       sourceValidators: new Map(),
     });
@@ -48,6 +55,7 @@ export const getTargetAndSourceValidatorsInfo = (
           effectiveBalance: parseGwei(
             sourceValidatorInfo.validator.effective_balance,
           ),
+          slashed: sourceValidatorInfo.validator.slashed,
         });
     }
   }


### PR DESCRIPTION
### Description

addFeeExemption is a delta (settledGrowth += amount), so comparing it against
cumulative settledGrowth meant nothing and offered a skip on nearly every
consolidation; skipping left the consolidated balance in the fee base.

A skip is now offered only on on-chain evidence that this batch's exemption
already landed: SettledGrowthSet in the same tx as CorrectionTimestampUpdated,
matching delta, 24h lookback. The evidence is advisory — same RPC could fake it.

Amount follows the spec: min(balance, effective_balance); slashed sources are
excluded because the CL skips them.

### Demo

<!-- If thee are visual changes add screenshots or record a [loom](https://www.loom.com/). -->

### Code review notes

<!-- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!-- List all possible edge cases and how to test them. -->

### Checklist:

- [ ]  Checked the changes locally.
- [x]  Created/updated unit tests.
- [x]  Created/updated README.md.

