### PR TITLE
feat: support Gloas validator proofs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
   },
   "dependencies": {
     "@chainsafe/blst": "^2.2.0",
-    "@chainsafe/persistent-merkle-tree": "^1.0.1",
-    "@chainsafe/ssz": "^1.2.2",
-    "@lodestar/types": "^1.35.0",
+    "@chainsafe/persistent-merkle-tree": "^1.3.0",
+    "@chainsafe/ssz": "^1.6.2",
+    "@lodestar/types": "^1.46.0",
     "@openzeppelin/merkle-tree": "^1.0.8",
     "@walletconnect/sign-client": "^2.22.3",
     "blessed": "^0.1.81",

--- a/tests/utils/first-validator-gindex.test.ts
+++ b/tests/utils/first-validator-gindex.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+const mockLogResult = vi.fn();
+
+vi.mock('utils', () => ({
+  logResult: mockLogResult,
+}));
+
+const importSubject = async () => {
+  const { getFirstValidatorGIndex } =
+    await import('../../utils/proof/first-validator-gindex.js');
+  return getFirstValidatorGIndex;
+};
+
+const rowsFor = async (forks: string[]) => {
+  const getFirstValidatorGIndex = await importSubject();
+  getFirstValidatorGIndex(forks);
+  return mockLogResult.mock.calls[0]?.[0]?.data as string[][];
+};
+
+// Values the verifiers are deployed with, see deploy params in lidofinance/core
+const CAPELLA_GINDEX =
+  '0x0000000000000000000000000000000000000000000000000056000000000028';
+const ELECTRA_GINDEX =
+  '0x0000000000000000000000000000000000000000000000000096000000000028';
+const GLOAS_GINDEX =
+  '0x0000000000000000000000000000000000000000000000000000000000016600';
+
+describe('getFirstValidatorGIndex', () => {
+  beforeEach(() => {
+    mockLogResult.mockClear();
+  });
+
+  test('packs first validator gindex with list depth before gloas', async () => {
+    const rows = await rowsFor(['capella', 'deneb', 'electra', 'fulu']);
+
+    expect(rows.map((row) => row[1])).toEqual([
+      CAPELLA_GINDEX,
+      CAPELLA_GINDEX,
+      ELECTRA_GINDEX,
+      ELECTRA_GINDEX,
+    ]);
+    expect(rows.map((row) => row[2])).toEqual([
+      'gIFirstValidatorPreGloas',
+      'gIFirstValidatorPreGloas',
+      'gIFirstValidatorPreGloas',
+      'gIFirstValidatorPreGloas',
+    ]);
+  });
+
+  test('returns the validators field gindex with zero width for gloas', async () => {
+    const rows = await rowsFor(['gloas']);
+
+    expect(rows[0]).toEqual(['gloas', GLOAS_GINDEX, 'gIValidators']);
+  });
+
+  test('rejects an unknown fork instead of emitting a gindex', async () => {
+    const getFirstValidatorGIndex = await importSubject();
+
+    expect(() => getFirstValidatorGIndex(['notafork'])).toThrow(
+      'Fork name [notafork] is not supported',
+    );
+    expect(mockLogResult).not.toHaveBeenCalled();
+  });
+});

--- a/utils/proof/constants.ts
+++ b/utils/proof/constants.ts
@@ -3,4 +3,5 @@ export const SupportedFork = {
   deneb: 'deneb',
   electra: 'electra',
   fulu: 'fulu',
+  gloas: 'gloas',
 };

--- a/utils/proof/first-validator-gindex.ts
+++ b/utils/proof/first-validator-gindex.ts
@@ -1,33 +1,53 @@
 import { ssz } from '@lodestar/types';
+import {
+  ListCompositeType,
+  ProgressiveListCompositeType,
+} from '@chainsafe/ssz';
 
 import { logResult } from 'utils';
 
 import { SupportedFork } from './constants.js';
 
-export const getFirstValidatorGIndex = (forks: string[]) => {
-  const gIndexes: Record<string, string> = {};
-  for (const fork of forks) {
-    const Fork = ssz[fork as keyof typeof SupportedFork];
-    const Validators = Fork.BeaconState.getPathInfo(['validators']).type;
+// Verifier constructor arg each gindex feeds, see CLProofVerifier.sol
+const PRE_GLOAS_PARAM = 'gIFirstValidatorPreGloas';
+const GLOAS_PARAM = 'gIValidators';
 
-    const gI = pack(
-      Fork.BeaconState.getPathInfo(['validators', 0]).gindex,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      Validators.limit,
-    );
-    gIndexes[fork] = toBytes32String(gI);
-  }
+export const getFirstValidatorGIndex = (forks: string[]) => {
+  const rows = forks.map((fork) => {
+    const Fork = ssz[fork as keyof typeof SupportedFork];
+    if (!Fork) throw new Error(`Fork name [${fork}] is not supported`);
+
+    const validators = Fork.BeaconState.getPathInfo(['validators']);
+
+    // Gloas: the list is progressive, so it has no fixed depth to pack. The
+    // verifier takes the validators field itself and derives each node.
+    if (validators.type instanceof ProgressiveListCompositeType) {
+      return [fork, toBytes32String(pack(validators.gindex, 0n)), GLOAS_PARAM];
+    }
+
+    if (!(validators.type instanceof ListCompositeType)) {
+      throw new TypeError(`Unexpected validators type for fork [${fork}]`);
+    }
+
+    const gI = Fork.BeaconState.getPathInfo(['validators', 0]).gindex;
+    return [
+      fork,
+      toBytes32String(pack(gI, widthOf(validators.type.limit))),
+      PRE_GLOAS_PARAM,
+    ];
+  });
+
   logResult({
-    data: Object.entries(gIndexes).map(([fork, gIndex]) => [fork, gIndex]),
+    data: rows,
     params: {
-      head: ['Fork', 'GIndex'],
+      head: ['Fork', 'GIndex', 'Deploy param'],
     },
   });
 };
 
-const pack = (gI: bigint, limit: number) => {
-  const width = limit ? BigInt(Math.log2(limit)) : 0n;
+const widthOf = (limit: number) => (limit ? BigInt(Math.log2(limit)) : 0n);
+
+const pack = (gI: bigint, width: bigint) => {
   return (gI << 8n) | width;
 };
 

--- a/utils/proof/proofs.ts
+++ b/utils/proof/proofs.ts
@@ -20,7 +20,9 @@ export type SupportedStateView = {
   >;
 }[keyof typeof SupportedFork];
 
-type Validator = ReturnType<SupportedStateView['validators']['getReadonly']>;
+// get(), not getReadonly() — gloas validators is a progressive list, whose view
+// has no getReadonly()
+type Validator = ReturnType<SupportedStateView['validators']['get']>;
 
 export type BeaconHeaderResponse = {
   slot: number;
@@ -60,7 +62,7 @@ export const createStateProof = async (
   if (validatorIndex >= stateView.validators.length)
     throw new Error(`ValidatorIndex ${validatorIndex} out of range`);
 
-  const validator = stateView.validators.getReadonly(Number(validatorIndex));
+  const validator = stateView.validators.get(Number(validatorIndex));
   const gIValidator = stateView.type.getPathInfo([
     'validators',
     Number(validatorIndex),

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,10 +143,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chainsafe/as-sha256@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@chainsafe/as-sha256@npm:1.2.0"
-  checksum: 10c0/277589bfbdfc692f669a19b87110f4eda033f94d2774cb6d8fc0f745bff3b9e895add862684dbf09ff19102ae79639fdfbc758ecafbbee1cb8e033c679c82aef
+"@chainsafe/as-sha256@npm:":
+  version: 1.2.4
+  resolution: "@chainsafe/as-sha256@npm:1.2.4"
+  checksum: 10c0/70dabaf349c19e7f0e55eeaf3314880396ff2cdf9572c483cf28f133cc236ac550f6d8ec2f760de3786b3d709f85e0c6fae592f342787c5b20805ff4816eba2f
   languageName: node
   linkType: hard
 
@@ -314,24 +314,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chainsafe/persistent-merkle-tree@npm:1.2.1, @chainsafe/persistent-merkle-tree@npm:^1.0.1":
-  version: 1.2.1
-  resolution: "@chainsafe/persistent-merkle-tree@npm:1.2.1"
+"@chainsafe/persistent-merkle-tree@npm:, @chainsafe/persistent-merkle-tree@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@chainsafe/persistent-merkle-tree@npm:1.3.0"
   dependencies:
-    "@chainsafe/as-sha256": "npm:1.2.0"
+    "@chainsafe/as-sha256": "npm:"
     "@chainsafe/hashtree": "npm:1.0.2"
     "@noble/hashes": "npm:^1.3.0"
-  checksum: 10c0/f3ebe05c1c7ee9807866fd930e8ff20389ff1a895bda5d5bfa8af819300a6e65134d3f29d807586c2eaf42bb8ded403bc2535ab90f241d65c6c51d677c1a29e0
+  checksum: 10c0/e1f2472662ce866a759a201bf8a08db4fcf91e0dd648125a93a022a363a5e47eee4f888d367d40fd7a84a42f62c62f0d631fee397efa1018174c8eb20c0ff4b6
   languageName: node
   linkType: hard
 
-"@chainsafe/ssz@npm:^1.2.2":
-  version: 1.3.0
-  resolution: "@chainsafe/ssz@npm:1.3.0"
+"@chainsafe/ssz@npm:^1.6.2":
+  version: 1.6.2
+  resolution: "@chainsafe/ssz@npm:1.6.2"
   dependencies:
-    "@chainsafe/as-sha256": "npm:1.2.0"
-    "@chainsafe/persistent-merkle-tree": "npm:1.2.1"
-  checksum: 10c0/19d916d697197dd3116082fe591b5f7cca1db84b4d09fd6c823a95c2cbf131d31a38c3517d2b74e48b5c152aeb4323fe38754b2917cbcf5a9d300c6a7fa3f5b7
+    "@chainsafe/as-sha256": "npm:"
+    "@chainsafe/persistent-merkle-tree": "npm:"
+  checksum: 10c0/764b10f2e994606f88b637852e7ce367e9639ce3d25aeeb144919736fccf9985ca5926fd2b1eae1c203a5535cb20c88781366e8670bbb31238103e5a0e08f957
   languageName: node
   linkType: hard
 
@@ -1173,12 +1173,12 @@ __metadata:
   resolution: "@lidofinance/lsv-cli@workspace:."
   dependencies:
     "@chainsafe/blst": "npm:^2.2.0"
-    "@chainsafe/persistent-merkle-tree": "npm:^1.0.1"
-    "@chainsafe/ssz": "npm:^1.2.2"
+    "@chainsafe/persistent-merkle-tree": "npm:^1.3.0"
+    "@chainsafe/ssz": "npm:^1.6.2"
     "@commitlint/cli": "npm:^20.5.0"
     "@commitlint/config-conventional": "npm:^17.4.4"
     "@commitlint/prompt": "npm:^19.8.1"
-    "@lodestar/types": "npm:^1.35.0"
+    "@lodestar/types": "npm:^1.46.0"
     "@openzeppelin/merkle-tree": "npm:^1.0.8"
     "@swc/core": "npm:^1.11.21"
     "@types/blessed": "npm:^0.1.25"
@@ -1232,21 +1232,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@lodestar/params@npm:^1.40.0":
-  version: 1.40.0
-  resolution: "@lodestar/params@npm:1.40.0"
-  checksum: 10c0/4b7c329aa8b081a57460e8de0c7a34edc0791b9769e686a8babdb2c006fec198c58043a984c57e69bc69aa842d0f362061b063709a82966a67149438e18028a3
+"@lodestar/params@npm:^1.46.0":
+  version: 1.46.0
+  resolution: "@lodestar/params@npm:1.46.0"
+  checksum: 10c0/96bd1219125495e04fdc456411cf1c9230597b2c2fe19a83a024a43f1afe28600d2030eecdf7d3b75b184bbff6bad597303294298b3fbdf4d472a516b597df6e
   languageName: node
   linkType: hard
 
-"@lodestar/types@npm:^1.35.0":
-  version: 1.40.0
-  resolution: "@lodestar/types@npm:1.40.0"
+"@lodestar/types@npm:^1.46.0":
+  version: 1.46.0
+  resolution: "@lodestar/types@npm:1.46.0"
   dependencies:
-    "@chainsafe/ssz": "npm:^1.2.2"
-    "@lodestar/params": "npm:^1.40.0"
+    "@chainsafe/ssz": "npm:^1.6.2"
+    "@lodestar/params": "npm:^1.46.0"
     ethereum-cryptography: "npm:^2.0.0"
-  checksum: 10c0/3cd5e3db38edc2b18d83e6cbcebd72a520ce7c65768584136a850f63d9ba9b2acdab98221cc26543c5c513b97c020a1ef4aa32d1cb587c1292d7b51a99a47526
+  checksum: 10c0/9dd5cf91a21b50dfa7bdd2c967d4b7e663b2f9c01674eb7697d6f487b976b03239b107ac382d7fdc74364acde6304ba84904a748b45888229b34218818bf8af4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

### Description

Prepare the CL proof pipeline for the Glamsterdam (Gloas) hardfork, ahead of
the verifier rework in lidofinance/core#1940.

- Add `gloas` to `SupportedFork`. Without it `fetchBeaconState` rejects any
  post-fork state with `Fork name [gloas] is not supported`.
- Make `fv-gindex` fork-aware. Under EIP-7688 `validators` is a progressive
  list with no fixed depth, so the verifier takes the gindex of the
  `validators` field itself (`gIValidators`) instead of a packed
  first-validator gindex. The output now also names the constructor arg each
  value feeds, so the two cannot be mixed up.
- Use `get()` instead of `getReadonly()` when reading a validator from the
  state view: `ProgressiveListCompositeTreeView` has no `getReadonly`, so on a
  Gloas state the old call throws `TypeError`.
- Bump `@lodestar/types` to 1.46.0 (first release with the Gloas progressive
  list) and align the direct `@chainsafe/ssz` / `@chainsafe/persistent-merkle-tree`
  ranges with it, so a single copy of each is resolved instead of the tree
  splitting into top-level and nested copies.

No contract-facing change: ABIs and read commands are untouched, so the CLI
keeps working against currently deployed contracts. The ABI rename that
core#1940 introduces lands separately, together with the contract cutover.

## Verification

Mainnet (fulu), validator 2298096 of a VaultHub-connected stVault
(WC `0x02` + `0x2df8CCb9…08ca7`):

- `createPDGProof` produced a 52-element proof; folding it by hand reproduces
  the finalized block root exactly.
- The deployed PredepositGuarantee accepted it via `validatePubKeyWCProof`.

Glamsterdam devnet (gloas active since epoch 3, chain 32382):

- `ssz.gloas.BeaconState` from @lodestar/types 1.46.0 hashes to the devnet's
  real `state_root` — schema and spec agree.
- Proofs for validator indices 0, 1, 5, 100 and 403 all reproduce the real
  block roots. Proof depth varies with index (15/18/21/27/30) as expected for
  a progressive list.
- `progressiveListNodeGIndex` + `concat` from core#1940's `GIndex.sol`,
  reimplemented in JS, yields exactly the gindex lodestar computes for every
  index tested.

### Demo

<!-- If thee are visual changes add screenshots or record a [loom](https://www.loom.com/). -->

### Code review notes

<!-- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!-- List all possible edge cases and how to test them. -->

### Checklist:

- [x]  Checked the changes locally.
- [x]  Created/updated unit tests.
- [ ]  Created/updated README.md.

