### PR TITLE
[WIP] feat: read PDG gindex getters from either contract layout

### DIFF
--- a/abi/PredepositGuarantee.ts
+++ b/abi/PredepositGuarantee.ts
@@ -952,6 +952,19 @@ export const PredepositGuaranteeAbi = [
   },
   {
     inputs: [],
+    name: 'GI_FIRST_VALIDATOR_PRE_GLOAS',
+    outputs: [
+      {
+        internalType: 'GIndex',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
     name: 'GI_PUBKEY_WC_PARENT',
     outputs: [
       {
@@ -966,6 +979,19 @@ export const PredepositGuaranteeAbi = [
   {
     inputs: [],
     name: 'GI_STATE_ROOT',
+    outputs: [
+      {
+        internalType: 'GIndex',
+        name: '',
+        type: 'bytes32',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'GI_VALIDATORS',
     outputs: [
       {
         internalType: 'GIndex',

--- a/features/pdg.ts
+++ b/features/pdg.ts
@@ -1,4 +1,4 @@
-import { Hex } from 'viem';
+import { ContractFunctionExecutionError, Hex } from 'viem';
 import {
   printError,
   showSpinner,
@@ -6,7 +6,10 @@ import {
   callReadMethodSilent,
   toHex,
 } from 'utils';
-import { getPredepositGuaranteeContract } from 'contracts';
+import {
+  getPredepositGuaranteeContract,
+  PredepositGuaranteeContract,
+} from 'contracts';
 
 import { checkPdgIsPaused } from './deposits/pdg.js';
 
@@ -16,6 +19,45 @@ export const VALIDATOR_STAGES = {
   2: 'PROVEN',
   3: 'ACTIVATED',
   5: 'COMPENSATED',
+};
+
+/**
+ * PDG renames its gindex getters when redeployed for Gloas (lidofinance/core#1940):
+ * GI_FIRST_VALIDATOR_PREV/CURR become GI_FIRST_VALIDATOR_PRE_GLOAS/GI_VALIDATORS.
+ * Networks are upgraded at different times and one ABI serves them all, so read
+ * whichever pair the deployment actually exposes.
+ */
+export const readPdgGIndexes = async (
+  contract: PredepositGuaranteeContract,
+) => {
+  try {
+    const [GI_FIRST_VALIDATOR_PRE_GLOAS, GI_VALIDATORS] = await Promise.all([
+      contract.read.GI_FIRST_VALIDATOR_PRE_GLOAS(),
+      contract.read.GI_VALIDATORS(),
+    ]);
+    return { GI_FIRST_VALIDATOR_PRE_GLOAS, GI_VALIDATORS };
+  } catch (err) {
+    // Missing getters revert; anything else (RPC, network) is a real failure
+    if (!(err instanceof ContractFunctionExecutionError)) throw err;
+  }
+
+  try {
+    const [GI_FIRST_VALIDATOR_CURR, GI_FIRST_VALIDATOR_PREV] =
+      await Promise.all([
+        contract.read.GI_FIRST_VALIDATOR_CURR(),
+        contract.read.GI_FIRST_VALIDATOR_PREV(),
+      ]);
+    return { GI_FIRST_VALIDATOR_CURR, GI_FIRST_VALIDATOR_PREV };
+  } catch (err) {
+    if (!(err instanceof ContractFunctionExecutionError)) throw err;
+    // Neither layout answered: the vendored ABI no longer matches the deployment
+    throw new Error(
+      `PredepositGuarantee at ${contract.address} exposes neither the Gloas gindex getters ` +
+        '(GI_FIRST_VALIDATOR_PRE_GLOAS/GI_VALIDATORS) nor the pre-Gloas ones ' +
+        '(GI_FIRST_VALIDATOR_CURR/PREV). Check abi/PredepositGuarantee.ts against the deployed contract.',
+      { cause: err },
+    );
+  }
 };
 
 // Get base info
@@ -28,8 +70,7 @@ export const getPdgBaseInfo = async () => {
       RESUME_ROLE,
       PAUSE_ROLE,
       BEACON_ROOTS,
-      GI_FIRST_VALIDATOR_CURR,
-      GI_FIRST_VALIDATOR_PREV,
+      gIndexes,
       GI_PUBKEY_WC_PARENT,
       GI_STATE_ROOT,
       MAX_SUPPORTED_WC_VERSION,
@@ -43,8 +84,7 @@ export const getPdgBaseInfo = async () => {
       contract.read.RESUME_ROLE(),
       contract.read.PAUSE_ROLE(),
       contract.read.BEACON_ROOTS(),
-      contract.read.GI_FIRST_VALIDATOR_CURR(),
-      contract.read.GI_FIRST_VALIDATOR_PREV(),
+      readPdgGIndexes(contract),
       contract.read.GI_PUBKEY_WC_PARENT(),
       contract.read.GI_STATE_ROOT(),
       contract.read.MAX_SUPPORTED_WC_VERSION(),
@@ -65,8 +105,7 @@ export const getPdgBaseInfo = async () => {
       RESUME_ROLE,
       PAUSE_ROLE,
       BEACON_ROOTS,
-      GI_FIRST_VALIDATOR_CURR,
-      GI_FIRST_VALIDATOR_PREV,
+      ...gIndexes,
       GI_PUBKEY_WC_PARENT,
       GI_STATE_ROOT,
       MAX_SUPPORTED_WC_VERSION,

--- a/programs/contracts/pdg/config.ts
+++ b/programs/contracts/pdg/config.ts
@@ -15,11 +15,22 @@ export const readCommandConfig: ReadProgramCommandConfig<
   GI_FIRST_VALIDATOR_CURR: {
     name: 'GI_FIRST_VALIDATOR_CURR',
     description:
-      'get GIndex of first validator in CL state tree after PIVOT_SLOT',
+      'get GIndex of first validator in CL state tree after PIVOT_SLOT (pre-Gloas deployments)',
   },
   GI_FIRST_VALIDATOR_PREV: {
     name: 'GI_FIRST_VALIDATOR_PREV',
-    description: 'get GIndex of first validator in CL state tree',
+    description:
+      'get GIndex of first validator in CL state tree (pre-Gloas deployments)',
+  },
+  GI_FIRST_VALIDATOR_PRE_GLOAS: {
+    name: 'GI_FIRST_VALIDATOR_PRE_GLOAS',
+    description:
+      'get GIndex of first validator in a pre-Gloas CL state tree (Gloas deployments)',
+  },
+  GI_VALIDATORS: {
+    name: 'GI_VALIDATORS',
+    description:
+      'get GIndex of the validators field, used from PIVOT_SLOT onwards (Gloas deployments)',
   },
   PIVOT_SLOT: {
     name: 'PIVOT_SLOT',

--- a/tests/integration/pdg.test.ts
+++ b/tests/integration/pdg.test.ts
@@ -7,6 +7,11 @@ import {
   validateExpectedData,
 } from './helpers/test-assertions.js';
 
+const FIRST_VALIDATOR_GINDEX =
+  '0x0000000000000000000000000000000000000000000000000096000000000028';
+const VALIDATORS_GINDEX =
+  '0x0000000000000000000000000000000000000000000000000000000000016600';
+
 const EXPECTED_DATA_HOODI = {
   CONTRACT_ADDRESS: '0xa5F55f3402beA2B14AE15Dae1b6811457D43581d',
   DEFAULT_ADMIN_ROLE:
@@ -16,10 +21,6 @@ const EXPECTED_DATA_HOODI = {
   PAUSE_ROLE:
     '0x8d0e4ae4847b49935b55c99f9c3ce025c87e7c4604c35b7ae56929bd32fa5a78',
   BEACON_ROOTS: '0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02',
-  GI_FIRST_VALIDATOR_CURR:
-    '0x0000000000000000000000000000000000000000000000000096000000000028',
-  GI_FIRST_VALIDATOR_PREV:
-    '0x0000000000000000000000000000000000000000000000000096000000000028',
   GI_PUBKEY_WC_PARENT:
     '0x0000000000000000000000000000000000000000000000000000000000000402',
   GI_STATE_ROOT:
@@ -27,9 +28,21 @@ const EXPECTED_DATA_HOODI = {
   MAX_SUPPORTED_WC_VERSION: 2,
   MIN_SUPPORTED_WC_VERSION: 1,
   PREDEPOSIT_AMOUNT: 1000000000000000000n,
-  PIVOT_SLOT: 0n,
   isPaused: false,
   resumeSinceTimestamp: 1765803516n,
+};
+
+// PDG renames these getters when redeployed for Gloas, so the expected shape
+// depends on which deployment hoodi is running.
+const EXPECTED_PRE_GLOAS = {
+  GI_FIRST_VALIDATOR_CURR: FIRST_VALIDATOR_GINDEX,
+  GI_FIRST_VALIDATOR_PREV: FIRST_VALIDATOR_GINDEX,
+  PIVOT_SLOT: 0n,
+};
+
+const EXPECTED_GLOAS = {
+  GI_FIRST_VALIDATOR_PRE_GLOAS: FIRST_VALIDATOR_GINDEX,
+  GI_VALIDATORS: VALIDATORS_GINDEX,
 };
 
 describe('Predeposit Guarantee Integration Tests', () => {
@@ -42,7 +55,24 @@ describe('Predeposit Guarantee Integration Tests', () => {
     expect(data).not.toBeNull();
     if (!data) return;
 
-    validateExpectedData(data, EXPECTED_DATA_HOODI, expect);
+    const isGloasDeployment = 'GI_VALIDATORS' in data;
+
+    validateExpectedData(
+      data,
+      isGloasDeployment
+        ? {
+            ...EXPECTED_DATA_HOODI,
+            ...EXPECTED_GLOAS,
+            PIVOT_SLOT: data.PIVOT_SLOT,
+          }
+        : { ...EXPECTED_DATA_HOODI, ...EXPECTED_PRE_GLOAS },
+      expect,
+    );
+
+    // TODO: pin PIVOT_SLOT once the Gloas fork slot is set on hoodi
+    expect(
+      isGloasDeployment ? data.PIVOT_SLOT > 0n : data.PIVOT_SLOT === 0n,
+    ).toBe(true);
 
     expect(isValidBytes32(data.PAUSE_ROLE)).toBe(true);
     expect(isValidBytes32(data.RESUME_ROLE)).toBe(true);

--- a/tests/utils/pdg-gindexes.test.ts
+++ b/tests/utils/pdg-gindexes.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from 'vitest';
+import { BaseError, ContractFunctionExecutionError } from 'viem';
+
+vi.mock('utils', async () => {
+  const logging = await vi.importActual<
+    typeof import('utils/logging/console.js')
+  >('../../utils/logging/console.js');
+  const errorHandler = await vi.importActual<
+    typeof import('utils/error-handler.js')
+  >('../../utils/error-handler.js');
+
+  return {
+    ...logging,
+    ...errorHandler,
+    showSpinner: () => () => {},
+    callReadMethodSilent: vi.fn(),
+  };
+});
+
+vi.mock('contracts', () => ({ getPredepositGuaranteeContract: vi.fn() }));
+
+const importSubject = async () => {
+  const { readPdgGIndexes } = await import('../../features/pdg.js');
+  return readPdgGIndexes;
+};
+
+type Contract = Parameters<Awaited<ReturnType<typeof importSubject>>>[0];
+
+const PRE_GLOAS =
+  '0x0000000000000000000000000000000000000000000000000096000000000028';
+const VALIDATORS =
+  '0x0000000000000000000000000000000000000000000000000000000000016600';
+
+const missingGetter = (functionName: string) =>
+  new ContractFunctionExecutionError(new BaseError('execution reverted'), {
+    abi: [],
+    functionName,
+  });
+
+const makeContract = (read: Record<string, () => Promise<unknown>>) =>
+  ({
+    read,
+    address: '0x0000000000000000000000000000000000000001',
+  }) as unknown as Contract;
+
+describe('readPdgGIndexes', () => {
+  it('reads the Gloas getters when the deployment exposes them', async () => {
+    const readPdgGIndexes = await importSubject();
+    const prev = vi.fn();
+    const curr = vi.fn();
+
+    const result = await readPdgGIndexes(
+      makeContract({
+        GI_FIRST_VALIDATOR_PRE_GLOAS: async () => PRE_GLOAS,
+        GI_VALIDATORS: async () => VALIDATORS,
+        GI_FIRST_VALIDATOR_PREV: prev,
+        GI_FIRST_VALIDATOR_CURR: curr,
+      }),
+    );
+
+    expect(result).toEqual({
+      GI_FIRST_VALIDATOR_PRE_GLOAS: PRE_GLOAS,
+      GI_VALIDATORS: VALIDATORS,
+    });
+    expect(prev).not.toHaveBeenCalled();
+    expect(curr).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the pre-Gloas getters when the Gloas ones are absent', async () => {
+    const readPdgGIndexes = await importSubject();
+
+    const result = await readPdgGIndexes(
+      makeContract({
+        GI_FIRST_VALIDATOR_PRE_GLOAS: async () => {
+          throw missingGetter('GI_FIRST_VALIDATOR_PRE_GLOAS');
+        },
+        GI_VALIDATORS: async () => {
+          throw missingGetter('GI_VALIDATORS');
+        },
+        GI_FIRST_VALIDATOR_PREV: async () => PRE_GLOAS,
+        GI_FIRST_VALIDATOR_CURR: async () => PRE_GLOAS,
+      }),
+    );
+
+    expect(result).toEqual({
+      GI_FIRST_VALIDATOR_PREV: PRE_GLOAS,
+      GI_FIRST_VALIDATOR_CURR: PRE_GLOAS,
+    });
+  });
+
+  it('names both layouts when the ABI matches neither deployment', async () => {
+    const readPdgGIndexes = await importSubject();
+    const absent = (functionName: string) => async () => {
+      throw missingGetter(functionName);
+    };
+
+    await expect(
+      readPdgGIndexes(
+        makeContract({
+          GI_FIRST_VALIDATOR_PRE_GLOAS: absent('GI_FIRST_VALIDATOR_PRE_GLOAS'),
+          GI_VALIDATORS: absent('GI_VALIDATORS'),
+          GI_FIRST_VALIDATOR_PREV: absent('GI_FIRST_VALIDATOR_PREV'),
+          GI_FIRST_VALIDATOR_CURR: absent('GI_FIRST_VALIDATOR_CURR'),
+        }),
+      ),
+    ).rejects.toThrow(/exposes neither the Gloas gindex getters/);
+  });
+
+  it('rethrows transport failures instead of falling back', async () => {
+    const readPdgGIndexes = await importSubject();
+    const prev = vi.fn();
+
+    await expect(
+      readPdgGIndexes(
+        makeContract({
+          GI_FIRST_VALIDATOR_PRE_GLOAS: async () => {
+            throw new Error('socket hang up');
+          },
+          GI_VALIDATORS: async () => VALIDATORS,
+          GI_FIRST_VALIDATOR_PREV: prev,
+          GI_FIRST_VALIDATOR_CURR: prev,
+        }),
+      ),
+    ).rejects.toThrow('socket hang up');
+
+    expect(prev).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION


### Description

PDG renames GI_FIRST_VALIDATOR_PREV/CURR to GI_FIRST_VALIDATOR_PRE_GLOAS and GI_VALIDATORS when redeployed for Gloas. One vendored ABI serves mainnet and hoodi, which are upgraded at different times, so read whichever pair the deployment exposes and fail with both names listed when neither answers. Make the hoodi gindex pins layout-aware.

### Demo

<!-- If thee are visual changes add screenshots or record a [loom](https://www.loom.com/). -->

### Code review notes

<!-- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!-- List all possible edge cases and how to test them. -->

### Checklist:

- [ ]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

